### PR TITLE
fix: menu widget & change asset modal default order

### DIFF
--- a/src/components/molecules/Common/AssetModal/index.tsx
+++ b/src/components/molecules/Common/AssetModal/index.tsx
@@ -91,9 +91,9 @@ const AssetModal: React.FC<Props> = ({
 
   const filteredAssets = useMemo(() => {
     if (!assets) return;
-    return assets.filter(a =>
-      a.url.match(fileType === "file" ? /\.kml$/ : /\.(jpg|jpeg|png|gif)$/),
-    );
+    return assets
+      .filter(a => a.url.match(fileType === "file" ? /\.kml$/ : /\.(jpg|jpeg|png|gif)$/))
+      .reverse(); // reversed to show newest at the top
   }, [assets, fileType]);
 
   return fileType === "video" ? (

--- a/src/components/molecules/Common/plugin/builtin/widgets/menu.tsx
+++ b/src/components/molecules/Common/plugin/builtin/widgets/menu.tsx
@@ -117,8 +117,9 @@ const Menu: WidgetComponent<Property, PluginProperty> = ({ property }) => {
                 key={b.id}
                 button={b}
                 pos={p}
-                menuItems={menuItems}
                 menuVisible={visibleMenuButton === b.id}
+                menuItems={menuItems}
+                itemOnClick={handleClick}
                 onClick={handleClick(b)}
                 onClose={closeMenu}
               />
@@ -134,10 +135,11 @@ const MenuButton: React.FC<{
   button: Button;
   menuVisible?: boolean;
   menuItems?: MenuItem[];
+  itemOnClick?: (b: Button | MenuItem) => () => void;
   pos: Position;
   onClick?: () => void;
   onClose?: () => void;
-}> = ({ button: b, menuVisible, menuItems, onClick, onClose, pos }) => {
+}> = ({ button: b, menuVisible, menuItems, itemOnClick, pos, onClick, onClose }) => {
   const referenceElement = useRef<HTMLDivElement>(null);
   const popperElement = useRef<HTMLDivElement>(null);
   const menuElement = useRef<HTMLDivElement>(null);
@@ -184,7 +186,7 @@ const MenuButton: React.FC<{
         {menuVisible && (
           <MenuWrapper ref={menuElement}>
             {menuItems?.map(i => (
-              <MenuItem tabIndex={0} key={i.id} item={i} onClick={onClick}>
+              <MenuItem tabIndex={0} key={i.id} item={i} onClick={itemOnClick?.(i)}>
                 {i.menuType !== "border" && i.menuTitle}
               </MenuItem>
             ))}


### PR DESCRIPTION
Bug fix:
- menu widget's item functionality wasn't working (link and flight)

Change:
- Asset modal now shows newest items at the top by default