### PR TITLE
fix: force logout when me query returns null

### DIFF
--- a/src/components/pages/TopPage/hooks.ts
+++ b/src/components/pages/TopPage/hooks.ts
@@ -24,8 +24,7 @@ export default () => {
   }, [isAuthenticated, navigate, currentTeam, setLocalState, data, teamId]);
 
   useEffect(() => {
-    if (authError || (!loading && !data?.me === null)) {
-      console.log("logout--------");
+    if (authError || (!loading && data?.me === null)) {
       logout();
     }
   }, [authError, data?.me, loading, logout]);

--- a/src/components/pages/TopPage/hooks.ts
+++ b/src/components/pages/TopPage/hooks.ts
@@ -24,7 +24,7 @@ export default () => {
   }, [isAuthenticated, navigate, currentTeam, setLocalState, data, teamId]);
 
   useEffect(() => {
-    if (authError || (!loading && data?.me === null)) {
+    if (authError || (!loading && !data?.me)) {
       logout();
     }
   }, [authError, data?.me, loading, logout]);

--- a/src/components/pages/TopPage/hooks.ts
+++ b/src/components/pages/TopPage/hooks.ts
@@ -14,7 +14,7 @@ export default () => {
 
   const [{ currentTeam }, setLocalState] = useLocalState(s => ({ currentTeam: s.currentTeam }));
 
-  const { data } = useTeamsQuery({ skip: !isAuthenticated });
+  const { data, loading } = useTeamsQuery({ skip: !isAuthenticated });
   const teamId = currentTeam?.id || data?.me?.myTeam.id;
 
   useEffect(() => {
@@ -24,10 +24,11 @@ export default () => {
   }, [isAuthenticated, navigate, currentTeam, setLocalState, data, teamId]);
 
   useEffect(() => {
-    if (authError) {
+    if (authError || (!loading && !data?.me === null)) {
+      console.log("logout--------");
       logout();
     }
-  }, [authError, logout]);
+  }, [authError, data?.me, loading, logout]);
 
   return {
     isLoading,


### PR DESCRIPTION
## Before
If the `me` query returns `null`. The screen becomes black and the user couldn't do anything.

## After
Without the valid query result, force the user to log out.