### PR TITLE
fix: layer panel bug

### DIFF
--- a/src/components/atoms/TreeView/Item.tsx
+++ b/src/components/atoms/TreeView/Item.tsx
@@ -167,6 +167,8 @@ export default function Item<T = unknown, R extends Element = Element>({
     />
   ) : null;
 
+  const childSelected = !!item.children?.find(c => selectedIds?.has(c?.id));
+
   return (
     <ItemComponent
       {...props}
@@ -188,7 +190,8 @@ export default function Item<T = unknown, R extends Element = Element>({
       draggable={draggable}
       droppable={droppable}
       shown={!!shown}
-      siblings={parentItem.children}>
+      siblings={parentItem.children}
+      childSelected={childSelected}>
       {children}
     </ItemComponent>
   );

--- a/src/components/atoms/TreeView/hooks.ts
+++ b/src/components/atoms/TreeView/hooks.ts
@@ -99,9 +99,6 @@ export default function <T = unknown>({
   useShallowCompareEffect(() => {
     if (!Array.isArray(expanded)) return;
 
-    expandedItems.current.clear();
-    expandedIds.current.clear();
-
     if (item?.children?.length) {
       const items = searchItems(item.children, expanded).filter(
         (i): i is [Item<T>, number[]] => !!i,

--- a/src/components/atoms/TreeView/types.ts
+++ b/src/components/atoms/TreeView/types.ts
@@ -6,6 +6,7 @@ export type ItemProps<T = unknown> = {
   item: Item<T>;
   index: number[];
   selected: boolean;
+  childSelected: boolean;
   expanded: boolean;
   multiple: boolean;
   depth: number;

--- a/src/components/molecules/EarthEditor/LayerTreeViewItem/Layer.tsx
+++ b/src/components/molecules/EarthEditor/LayerTreeViewItem/Layer.tsx
@@ -37,6 +37,7 @@ export type Props = {
   disabled?: boolean;
   expanded?: boolean;
   selected?: boolean;
+  childSelected?: boolean;
   dropType?: DropType;
   allSiblingsDoesNotHaveChildren?: boolean;
   onClick: () => void;
@@ -71,6 +72,7 @@ const Layer: React.ForwardRefRenderFunction<HTMLDivElement, Props> = (
     },
     expanded,
     selected,
+    childSelected,
     dropType,
     allSiblingsDoesNotHaveChildren,
     onVisibilityChange,
@@ -178,6 +180,7 @@ const Layer: React.ForwardRefRenderFunction<HTMLDivElement, Props> = (
       onDoubleClick={handleDoubleClick}
       dropType={dropType}
       selected={selected}
+      childSelected={childSelected}
       disabled={deactivated}
       underlined={underlined}
       type={type}
@@ -284,6 +287,7 @@ const Layer: React.ForwardRefRenderFunction<HTMLDivElement, Props> = (
 
 const Wrapper = styled.div<{
   selected?: boolean;
+  childSelected?: boolean;
   dropType?: DropType;
   hover?: boolean;
   disabled?: boolean;
@@ -323,6 +327,8 @@ const Wrapper = styled.div<{
       : "transparent"};
   border-bottom-color: ${({ underlined, theme }) => underlined && theme.colors.outline.weakest};
   font-size: ${fonts.sizes.xs}px;
+  border-right: ${({ childSelected, theme }) =>
+    childSelected ? `2px solid ${theme.colors.brand.main}` : undefined};
 `;
 
 const ArrowIconWrapper = styled.div<{ allSiblingsDoesNotHaveChildren?: boolean }>`

--- a/src/components/molecules/EarthEditor/LayerTreeViewItem/index.tsx
+++ b/src/components/molecules/EarthEditor/LayerTreeViewItem/index.tsx
@@ -27,6 +27,7 @@ function LayerTreeViewItem<T = unknown>(
     shown,
     item,
     selected,
+    childSelected,
     expanded,
     dropType,
     canDrop,
@@ -79,6 +80,7 @@ function LayerTreeViewItem<T = unknown>(
         onRemove={onRemove}
         onGroupCreate={onGroupCreate}
         onImport={onImport}
+        childSelected={childSelected}
       />
       {children && (
         <Children expanded={expanded} dropType={canDrop ? dropType : undefined}>


### PR DESCRIPTION
- fix bug where deselecting a child layer would close the folder
-  update to show indicator beside parent when child is selected
<img width="297" alt="Screen Shot 2021-06-15 at 15 49 00" src="https://user-images.githubusercontent.com/34051327/122005997-40a06d00-cdf1-11eb-9f5e-7abb21c6dcbb.png">
