### PR TITLE
fix: menu button width

### DIFF
--- a/src/components/molecules/Common/plugin/builtin/widgets/menu.tsx
+++ b/src/components/molecules/Common/plugin/builtin/widgets/menu.tsx
@@ -113,16 +113,18 @@ const Menu: WidgetComponent<Property, PluginProperty> = ({ property }) => {
         <Wrapper key={p} position={p}>
           {buttons?.[p].map(b =>
             !b.buttonInvisible ? (
-              <MenuButton
-                key={b.id}
-                button={b}
-                pos={p}
-                menuVisible={visibleMenuButton === b.id}
-                menuItems={menuItems}
-                itemOnClick={handleClick}
-                onClick={handleClick(b)}
-                onClose={closeMenu}
-              />
+              <div style={{ position: "relative" }}>
+                <MenuButton
+                  key={b.id}
+                  button={b}
+                  pos={p}
+                  menuVisible={visibleMenuButton === b.id}
+                  menuItems={menuItems}
+                  itemOnClick={handleClick}
+                  onClick={handleClick(b)}
+                  onClose={closeMenu}
+                />
+              </div>
             ) : null,
           )}
         </Wrapper>
@@ -181,7 +183,12 @@ const MenuButton: React.FC<{
       </Button>
       <div
         ref={popperElement}
-        style={{ ...styles.popper, display: menuVisible ? styles.popper.display : "none" }}
+        style={{
+          minWidth: "200px",
+          width: "100%",
+          position: "absolute",
+          display: menuVisible ? styles.popper.display : "none",
+        }}
         {...attributes}>
         {menuVisible && (
           <MenuWrapper ref={menuElement}>
@@ -234,6 +241,8 @@ const StyledIcon = styled(Icon)<{ margin: boolean }>`
 `;
 
 const MenuWrapper = styled.div<{ visible?: boolean }>`
+  min-width: 200px;
+  width: 100%;
   position: absolute;
   top: 0;
   left: 0;

--- a/src/components/molecules/Common/plugin/builtin/widgets/menu.tsx
+++ b/src/components/molecules/Common/plugin/builtin/widgets/menu.tsx
@@ -241,7 +241,6 @@ const StyledIcon = styled(Icon)<{ margin: boolean }>`
 `;
 
 const MenuWrapper = styled.div<{ visible?: boolean }>`
-  min-width: 200px;
   width: 100%;
   position: absolute;
   top: 0;


### PR DESCRIPTION
# Overview
When the menu has been opened the style should be kept well

## What I've done
I made the menu min-width of 200px
but if the button is wider the menu will take the whole width (as shown in the screenshots)

## Screenshot
![1](https://user-images.githubusercontent.com/78056580/123228937-868abe80-d4de-11eb-975b-7c5b697d1f2d.png)
![2](https://user-images.githubusercontent.com/78056580/123228949-8985af00-d4de-11eb-9bd9-3bbcb262439f.png)


## Which point I want you to review particularly

## Memo
