### PR TITLE
fix: flight issue with photo overlay in Storytelling feature

### DIFF
--- a/src/components/molecules/Common/plugin/builtin/primitives/photooverlay.tsx
+++ b/src/components/molecules/Common/plugin/builtin/primitives/photooverlay.tsx
@@ -99,7 +99,7 @@ const PhotoOverlay: PrimitiveComponent<Property, PluginProperty> = ({
   useEffect(() => {
     const c = viewer?.camera;
 
-    if (prevMode > 0 && mode === 0 && c && prevCamera.current) {
+    if (prevMode > 0 && mode === 0 && c && prevCamera.current && isSelected) {
       c.flyTo({
         destination: Cartesian3.fromDegrees(
           prevCamera.current.lng,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,7 +2158,7 @@
   dependencies:
     "@types/gapi.client" "*"
 
-"@mdx-js/loader@^1.6.19":
+"@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"
   integrity sha512-9CjGwy595NaxAYp0hF9B/A0lH6C8Rms97e2JS9d3jVUtILn6pT5i5IV965ra3lIWc7Rs1GG1tBdVF7dCowYe6Q==


### PR DESCRIPTION
# Overview
Unpredictable and weird camera/flight behaviour with photo overlays in the storytelling feature. Camera will sometimes shoot far away from the earth before settling into the correct position. Sometimes the flight to the next photo overlay will stop abruptly and return to the prev position. Then, on next story the flight will final move to the 2nd(now previous) position.

## What I've done
Add a condition to the photo overlay so that it will not return to previous position if NOT selected still.

## What I haven't done

## How I tested
Tested storytelling with photo overlay stories, all defaults.
Tested storytelling with photo overlay stories, first, then second, then third photo overlay story getting set camera positions.
Tested storytelling with photo overlay stories with both photo overlays AND storytelling setting camera.

## Screenshot

## Which point I want you to review particularly

## Memo
