### PR TITLE
fix: show layers in storytelling without names

### DIFF
--- a/src/components/molecules/Common/plugin/builtin/widgets/storytelling.tsx
+++ b/src/components/molecules/Common/plugin/builtin/widgets/storytelling.tsx
@@ -58,7 +58,7 @@ const Storytelling: WidgetComponent<Property, PluginProperty> = ({ property }) =
           const title = layers.find(l => l?.id === story.layer)?.title;
           return {
             ...story,
-            title,
+            title: title || story.title,
           };
         })
         .filter((s): s is Story => !!s)

--- a/src/components/molecules/Common/plugin/builtin/widgets/storytelling.tsx
+++ b/src/components/molecules/Common/plugin/builtin/widgets/storytelling.tsx
@@ -56,13 +56,10 @@ const Storytelling: WidgetComponent<Property, PluginProperty> = ({ property }) =
       property?.stories
         ?.map(story => {
           const title = layers.find(l => l?.id === story.layer)?.title;
-          if (title) {
-            return {
-              ...story,
-              title,
-            };
-          }
-          return undefined;
+          return {
+            ...story,
+            title,
+          };
         })
         .filter((s): s is Story => !!s)
     );


### PR DESCRIPTION
# Overview

## What I've done
Just a bandaid fix as a better fix is coming with the reworked plugin system!

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
