### PR TITLE
fix: account dropdowns show wrong values

### DIFF
--- a/src/components/organisms/Settings/Account/index.tsx
+++ b/src/components/organisms/Settings/Account/index.tsx
@@ -25,15 +25,17 @@ const Account: React.FC<Props> = () => {
     <SettingPage teamId={currentTeam?.id} projectId={currentProject?.id}>
       <SettingsHeader title={intl.formatMessage({ defaultMessage: "Account" })} />
       <ProfileSection username={me?.name} updateName={updateName} />
-      <AccountSection
-        email={me?.email}
-        lang={me?.lang}
-        appTheme={me?.theme ? me.theme.toUpperCase() : "DARK"}
-        hasPassword={hasPassword}
-        updatePassword={updatePassword}
-        updateLanguage={updateLanguage}
-        updateTheme={updateTheme}
-      />
+      {me && (
+        <AccountSection
+          email={me?.email}
+          lang={me?.lang}
+          appTheme={me?.theme ? me.theme.toUpperCase() : "DARK"}
+          hasPassword={hasPassword}
+          updatePassword={updatePassword}
+          updateLanguage={updateLanguage}
+          updateTheme={updateTheme}
+        />
+      )}
     </SettingPage>
   );
 };


### PR DESCRIPTION
# Overview
Dropdown in settings page, always selects a wrong default value after refreshing the page.

## What I've done
Load component when `me` value is available

## How I tested
1- Go to Account page
2- Set language to Japanese, or set theme to light theme
3- Refresh page
4- Click on edit dropdown value
5- Right value appears


## Screenshot

https://user-images.githubusercontent.com/78056580/127628724-f291e6e4-e9a9-45bd-8b17-e04beeb13b4c.mp4



fixes https://github.com/reearth/reearth/issues/88
