### PR TITLE
fix: color related bugs

### DIFF
--- a/src/components/molecules/EarthEditor/PropertyPane/PropertyField/ColorField/index.tsx
+++ b/src/components/molecules/EarthEditor/PropertyPane/PropertyField/ColorField/index.tsx
@@ -43,15 +43,6 @@ const ColorField: React.FC<Props> = ({ value, onChange, overridden, linked }) =>
     }
   }, [value]);
 
-  useEffect(() => {
-    if (colorState == null) return;
-    const color = getHexString(rgba);
-    if (!color) return;
-    if (color != colorState) {
-      setColor(color);
-    }
-  }, [colorState, rgba]);
-
   const { styles, attributes } = usePopper(wrapperRef.current, pickerRef.current, {
     placement: "bottom-start",
     modifiers: [

--- a/src/components/molecules/Visualizer/Infobox/Frame/index.tsx
+++ b/src/components/molecules/Visualizer/Infobox/Frame/index.tsx
@@ -99,7 +99,7 @@ const InfoBox: React.FC<Props> = ({
           direction="column"
           onClick={handleOpen}>
           {isSmallWindow && !noContent && <StyledIcon icon="arrowUp" size={24} open={open} />}
-          <Text size="m" weight="bold">
+          <Text size="m" weight="bold" customColor>
             <TitleText>{title || " "}</TitleText>
           </Text>
           {!isSmallWindow && <StyledIcon icon="arrowDown" size={24} open={open} />}


### PR DESCRIPTION
# Overview
The color picker wouldn't allow hex input and the infobox's title color wouldn't change when typography's color was changed.

## What I've done
Removed troublesome useEffect from color picker to get hex input working.
Add the customColor prop to the infobox's title component so it allowed the chosen color.
