### PR TITLE
refactor: replace deprecated gql fields, pass widgetId to widget mutations

### DIFF
--- a/src/components/molecules/EarthEditor/OutlinePane/hooks.tsx
+++ b/src/components/molecules/EarthEditor/OutlinePane/hooks.tsx
@@ -26,15 +26,19 @@ export type LayerItem = {
 };
 
 export type Widget = {
-  id: string;
+  id?: string;
+  pluginId: string;
+  extensionId: string;
   title: string;
   description?: string;
   enabled?: boolean;
   icon?: string;
 };
 
-export type ItemType = "root" | "scene" | "layer" | "widget";
-export type ItemEx = { type: ItemType };
+export type ItemType = ItemEx["type"];
+export type ItemEx =
+  | { type: "root" | "scene" | "layer" | "scenes" | "widgets" }
+  | { type: "widget"; widgetId?: string; pluginId: string; extensionId: string };
 export type TreeViewItem = LayerTreeViewItemItem<ItemEx>;
 
 export default ({
@@ -68,7 +72,7 @@ export default ({
   onLayerImport?: (file: File, format: Format) => void;
   onLayerRemove?: (id: string) => void;
   onSceneSelect?: () => void;
-  onWidgetSelect?: (id: string) => void;
+  onWidgetSelect?: (widgetId: string | undefined, pluginId: string, extensionId: string) => void;
   onLayerMove?: (
     src: string,
     dest: string,
@@ -95,7 +99,7 @@ export default ({
       if (item.content.type === "scene") {
         onSceneSelect?.();
       } else if (item.content.type === "widget") {
-        onWidgetSelect?.(item.id);
+        onWidgetSelect?.(item.content.widgetId, item.content.pluginId, item.content.extensionId);
       } else if (item.content.type === "layer") {
         onLayerSelect?.(
           item.id,
@@ -154,7 +158,6 @@ export default ({
         {
           id: "scene",
           content: {
-            id: "scene",
             type: "scene",
             icon: "scene",
             title: sceneTitle,
@@ -169,8 +172,7 @@ export default ({
         {
           id: "widgets",
           content: {
-            id: "widgets",
-            type: "widget",
+            type: "widgets",
             icon: "widget",
             title: widgetTitle,
             group: true,
@@ -181,9 +183,12 @@ export default ({
           expandable: true,
           selectable: false,
           children: widgets?.map(w => ({
-            id: w.id,
+            id: `${w.pluginId}/${w.extensionId}`,
             content: {
-              id: w.id,
+              id: `${w.pluginId}/${w.extensionId}`,
+              widgetId: w.id,
+              pluginId: w.pluginId,
+              extensionId: w.extensionId,
               type: "widget",
               title: w.title,
               description: w.description,

--- a/src/components/molecules/EarthEditor/OutlinePane/index.stories.tsx
+++ b/src/components/molecules/EarthEditor/OutlinePane/index.stories.tsx
@@ -24,6 +24,8 @@ export default {
 const widgets: Widget[] = [
   {
     id: "Widget1",
+    pluginId: "xxx",
+    extensionId: "yyy",
     title: "Widget1",
     enabled: true,
   },

--- a/src/components/molecules/EarthEditor/OutlinePane/index.tsx
+++ b/src/components/molecules/EarthEditor/OutlinePane/index.tsx
@@ -30,7 +30,7 @@ export type Props = {
   onLayerRemove?: (id: string) => void;
   onLayerSelect?: (layerId: string, ...i: number[]) => void;
   onSceneSelect?: () => void;
-  onWidgetSelect?: (id: string) => void;
+  onWidgetSelect?: (widgetId: string | undefined, pluginId: string, extensionId: string) => void;
   onLayerMove?: (
     layer: string,
     destLayer: string,
@@ -111,7 +111,6 @@ const OutlinePane: React.FC<Props> = ({
           />
         )}
       </OutlineItemsWrapper>
-
       <LayersItemWrapper>
         {layersItem && (
           <TreeView<TreeViewItem, HTMLDivElement>

--- a/src/components/molecules/EarthEditor/PropertyPane/PropertyItem/index.stories.tsx
+++ b/src/components/molecules/EarthEditor/PropertyPane/PropertyItem/index.stories.tsx
@@ -87,7 +87,7 @@ export const NamedList = () => (
     item={{
       id: "foo",
       schemaGroup: "foo",
-      nameField: "bar",
+      representativeField: "bar",
       schemaFields: [
         {
           id: "bar",
@@ -130,7 +130,7 @@ export const LayerMode = () => (
     item={{
       id: "foo",
       schemaGroup: "foo",
-      nameField: "foo",
+      representativeField: "foo",
       schemaFields: [
         {
           id: "foo",

--- a/src/components/molecules/EarthEditor/PropertyPane/PropertyItem/index.tsx
+++ b/src/components/molecules/EarthEditor/PropertyPane/PropertyItem/index.tsx
@@ -53,7 +53,7 @@ export type ItemCommon = {
   schemaGroup: string;
   title?: string;
   schemaFields: SchemaField[];
-  nameField?: string;
+  representativeField?: string;
   only?: {
     field: string;
     value: string | boolean;
@@ -143,10 +143,10 @@ const PropertyItem: React.FC<Props> = ({
 
   const isList = item && "items" in item;
   const layerMode = useMemo(() => {
-    if (!isList || !item?.nameField) return false;
-    const sf = item.schemaFields.find(f => f.id === item.nameField);
+    if (!isList || !item?.representativeField) return false;
+    const sf = item.schemaFields.find(f => f.id === item.representativeField);
     return sf?.type === "ref" && sf.ui === "layer";
-  }, [isList, item?.nameField, item?.schemaFields]);
+  }, [isList, item?.representativeField, item?.schemaFields]);
 
   const groups = useMemo<(GroupListItem | Group)[]>(
     () => (item && "items" in item ? item.items : item ? [item] : []),
@@ -161,12 +161,14 @@ const PropertyItem: React.FC<Props> = ({
         .map<PropertyListItem | undefined>(i => {
           if (!i.id) return;
 
-          const nameField = item?.nameField
-            ? i.fields.find(f => f.id === item.nameField)
+          const representativeField = item?.representativeField
+            ? i.fields.find(f => f.id === item.representativeField)
             : undefined;
-          const nameSchemaField = item?.schemaFields?.find(sf => sf.id === item.nameField);
+          const nameSchemaField = item?.schemaFields?.find(
+            sf => sf.id === item.representativeField,
+          );
 
-          const value = nameField?.value || nameSchemaField?.defaultValue;
+          const value = representativeField?.value || nameSchemaField?.defaultValue;
 
           const choice = nameSchemaField?.choices
             ? nameSchemaField?.choices?.find(c => c.key === value)?.label
@@ -283,7 +285,7 @@ const PropertyItem: React.FC<Props> = ({
       )}
       {!!item &&
         schemaFields?.map(f => {
-          if (layerMode && f.schemaField.id === item.nameField) return null;
+          if (layerMode && f.schemaField.id === item.representativeField) return null;
           return (
             <PropertyField
               key={f.schemaField.id}

--- a/src/components/organisms/EarthEditor/OutlinePane/hooks.tsx
+++ b/src/components/organisms/EarthEditor/OutlinePane/hooks.tsx
@@ -78,12 +78,15 @@ export default () => {
           .map((e): Widget => {
             const pluginId = plugin.id;
             const extensionId = e.extensionId;
-            const enabled = scene?.widgets.find(
+            // note: multiple widget is not supported now
+            const widget = scene?.widgets.find(
               w => w.pluginId === plugin.id && w.extensionId === e.extensionId,
-            )?.enabled;
+            );
             return {
-              id: `${plugin.id}/${e.extensionId}`,
-              enabled,
+              id: widget?.id,
+              pluginId,
+              extensionId: e.extensionId,
+              enabled: !!widget?.enabled,
               title: e.translatedName,
               description: e.translatedDescription,
               icon: e.icon || (pluginId === "reearth" ? extensionId : undefined),
@@ -123,8 +126,13 @@ export default () => {
   }, [select, selectBlock]);
 
   const selectWidget = useCallback(
-    (id: string) => {
-      select({ type: "widget", widgetId: id });
+    (widgetId: string | undefined, pluginId: string, extensionId: string) => {
+      select({
+        type: "widget",
+        widgetId,
+        pluginId,
+        extensionId,
+      });
       selectBlock(undefined);
     },
     [select, selectBlock],

--- a/src/components/organisms/EarthEditor/OutlinePane/hooks.tsx
+++ b/src/components/organisms/EarthEditor/OutlinePane/hooks.tsx
@@ -253,7 +253,8 @@ export default () => {
     sceneDescription,
     selectedType: selected?.type,
     selectedLayerId: selected?.type === "layer" ? selected.layerId : undefined,
-    selectedWidgetId: selected?.type === "widget" ? selected.widgetId : undefined,
+    selectedWidgetId:
+      selected?.type === "widget" ? `${selected.pluginId}/${selected.extensionId}` : undefined,
     loading: loading && WidgetLoading,
     selectLayer,
     selectScene,

--- a/src/components/organisms/EarthEditor/PropertyPane/convert.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/convert.ts
@@ -62,13 +62,13 @@ const toItem = (
 ): Item | undefined => {
   const common: Pick<
     Item,
-    "id" | "schemaGroup" | "title" | "only" | "schemaFields" | "nameField"
+    "id" | "schemaGroup" | "title" | "only" | "schemaFields" | "representativeField"
   > = {
     id: item?.id,
     schemaGroup: schemaGroup.schemaGroupId,
     title: schemaGroup.translatedTitle,
     only: toCond(schemaGroup.isAvailableIf),
-    nameField: schemaGroup.name ?? undefined,
+    representativeField: schemaGroup.representativeFieldId ?? undefined,
     schemaFields: schemaGroup.fields
       .map((f): SchemaField | undefined => {
         const t = valueTypeFromGQL(f.type);
@@ -78,12 +78,12 @@ const toItem = (
           type: t,
           defaultValue: f.defaultValue,
           suffix: f.suffix ?? undefined,
-          name: f.translatedName,
+          name: f.translatedTitle,
           description: f.translatedDescription,
           only: toCond(f.isAvailableIf),
           choices: f.choices?.map(c => ({
             key: c.key,
-            label: c.translatedLabel,
+            label: c.translatedTitle,
           })),
           ui: toUi(f.ui),
           min: f.min ?? undefined,
@@ -95,15 +95,13 @@ const toItem = (
   };
 
   if (schemaGroup.isList) {
-    const items = (item && "groups" in item ? item.groups : []).map(
-      (item2, i): GroupListItem => {
-        const mergedGroup = merged && "groups" in merged ? merged.groups[i] : undefined;
-        return {
-          id: item2.id,
-          fields: toFields(schemaGroup, item2, mergedGroup),
-        };
-      },
-    );
+    const items = (item && "groups" in item ? item.groups : []).map((item2, i): GroupListItem => {
+      const mergedGroup = merged && "groups" in merged ? merged.groups[i] : undefined;
+      return {
+        id: item2.id,
+        fields: toFields(schemaGroup, item2, mergedGroup),
+      };
+    });
     return {
       ...common,
       items,
@@ -219,9 +217,9 @@ const toUi = (ui: PropertySchemaFieldUi | null | undefined): SchemaField["ui"] =
 export const convertLinkableDatasets = (
   data?: GetLinkableDatasetsQuery,
 ): DatasetSchema[] | undefined => {
-  return (data?.datasetSchemas?.nodes as
-    | GetLinkableDatasetsQuery["datasetSchemas"]["nodes"]
-    | undefined)
+  return (
+    data?.datasetSchemas?.nodes as GetLinkableDatasetsQuery["datasetSchemas"]["nodes"] | undefined
+  )
     ?.map((s): DatasetSchema | undefined => {
       return s
         ? {

--- a/src/components/organisms/EarthEditor/PropertyPane/hooks-queries.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/hooks-queries.ts
@@ -8,6 +8,7 @@ import {
   useAssetsQuery,
 } from "@reearth/gql";
 import { convert, Pane, convertLinkableDatasets, convertLayers } from "./convert";
+import { Selected } from "@reearth/state";
 
 export type Mode = "infobox" | "scene" | "layer" | "block" | "widget";
 
@@ -16,17 +17,15 @@ export type AssetNodes = NonNullable<AssetsQuery["assets"]["nodes"][number]>[];
 export default ({
   sceneId,
   rootLayerId,
-  selectedLayer,
+  selected,
   selectedBlock,
-  selectedWidgetId,
   teamId,
   mode,
 }: {
   sceneId?: string;
   rootLayerId?: string;
-  selectedLayer?: string;
+  selected?: Selected;
   selectedBlock?: string;
-  selectedWidgetId?: string;
   teamId?: string;
   mode: Mode;
 }) => {
@@ -53,8 +52,9 @@ export default ({
     error: layerPropertyError,
     data: layerPropertyData,
   } = useGetLayerPropertyQuery({
-    variables: { layerId: selectedLayer || "" },
-    skip: !selectedLayer || (mode !== "layer" && mode !== "block" && mode !== "infobox"),
+    variables: { layerId: selected?.type === "layer" ? selected.layerId : "" },
+    skip:
+      selected?.type !== "layer" || (mode !== "layer" && mode !== "block" && mode !== "infobox"),
   });
 
   const { data: linkableDatasets } = useGetLinkableDatasetsQuery({
@@ -119,10 +119,13 @@ export default ({
       ? layerPropertyData.layer.linkedDatasetId ?? undefined
       : undefined;
   const isInfoboxCreatable =
-    !!selectedLayer && mode === "infobox" && !layerPropertyData?.layer?.infobox;
+    selected?.type === "layer" && mode === "infobox" && !layerPropertyData?.layer?.infobox;
   const selectedWidget = useMemo(
-    () => (selectedWidgetId ? scene?.widgets.find(w => selectedWidgetId === w.id) : undefined),
-    [scene?.widgets, selectedWidgetId],
+    () =>
+      selected?.type === "widget"
+        ? scene?.widgets.find(w => selected.widgetId === w.id)
+        : undefined,
+    [scene?.widgets, selected],
   );
 
   const pane = useMemo<Pane | undefined>(() => {
@@ -137,12 +140,14 @@ export default ({
     }
 
     if (mode === "widget") {
-      if (!selectedWidgetId) return undefined;
-      const w = scene?.widgets.find(w => selectedWidgetId === w.id);
+      if (selected?.type !== "widget") return;
+      const w = selected.widgetId
+        ? scene?.widgets.find(w => selected.widgetId === w.id)
+        : undefined;
       return {
-        id: selectedWidgetId,
-        pluginId: w?.pluginId,
-        extensionId: w?.extensionId,
+        id: selected.widgetId || `${selected.pluginId}/${selected.widgetId}`,
+        pluginId: selected.pluginId,
+        extensionId: selected.extensionId,
         mode: "widget",
         propertyId: w?.property?.id,
         items: convert(w?.property, null),
@@ -159,7 +164,15 @@ export default ({
       title: layerPropertyData?.layer?.name,
       group: layerPropertyData?.layer?.__typename === "LayerGroup",
     };
-  }, [items, mode, propertyId, scene?.widgets, selectedWidgetId, layerPropertyData?.layer]);
+  }, [
+    mode,
+    propertyId,
+    items,
+    layerPropertyData?.layer?.name,
+    layerPropertyData?.layer?.__typename,
+    selected,
+    scene?.widgets,
+  ]);
   const datasetSchemas = useMemo(
     () => convertLinkableDatasets(linkableDatasets),
     [linkableDatasets],

--- a/src/components/organisms/EarthEditor/PropertyPane/hooks-queries.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/hooks-queries.ts
@@ -26,7 +26,7 @@ export default ({
   rootLayerId?: string;
   selectedLayer?: string;
   selectedBlock?: string;
-  selectedWidgetId?: { pluginId: string; extensionId: string };
+  selectedWidgetId?: string;
   teamId?: string;
   mode: Mode;
 }) => {
@@ -121,14 +121,7 @@ export default ({
   const isInfoboxCreatable =
     !!selectedLayer && mode === "infobox" && !layerPropertyData?.layer?.infobox;
   const selectedWidget = useMemo(
-    () =>
-      selectedWidgetId
-        ? scene?.widgets.find(
-            w =>
-              selectedWidgetId.pluginId === w.pluginId &&
-              selectedWidgetId.extensionId === w.extensionId,
-          )
-        : undefined,
+    () => (selectedWidgetId ? scene?.widgets.find(w => selectedWidgetId === w.id) : undefined),
     [scene?.widgets, selectedWidgetId],
   );
 
@@ -145,13 +138,11 @@ export default ({
 
     if (mode === "widget") {
       if (!selectedWidgetId) return undefined;
-      const w = scene?.widgets.find(
-        w =>
-          w.pluginId === selectedWidgetId.pluginId &&
-          w.extensionId === selectedWidgetId.extensionId,
-      );
+      const w = scene?.widgets.find(w => selectedWidgetId === w.id);
       return {
-        id: selectedWidgetId.pluginId + "/" + selectedWidgetId.extensionId,
+        id: selectedWidgetId,
+        pluginId: w?.pluginId,
+        extensionId: w?.extensionId,
         mode: "widget",
         propertyId: w?.property?.id,
         items: convert(w?.property, null),
@@ -185,7 +176,6 @@ export default ({
     linkedDatasetSchemaId,
     isInfoboxCreatable,
     datasetSchemas,
-    scene,
     layers,
     assets,
     selectedWidget,

--- a/src/components/organisms/EarthEditor/PropertyPane/hooks-queries.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/hooks-queries.ts
@@ -145,7 +145,7 @@ export default ({
         ? scene?.widgets.find(w => selected.widgetId === w.id)
         : undefined;
       return {
-        id: selected.widgetId || `${selected.pluginId}/${selected.widgetId}`,
+        id: selected.widgetId || `${selected.pluginId}/${selected.extensionId}`,
         pluginId: selected.pluginId,
         extensionId: selected.extensionId,
         mode: "widget",

--- a/src/components/organisms/EarthEditor/PropertyPane/hooks.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/hooks.ts
@@ -64,8 +64,7 @@ export default (mode: Mode) => {
     sceneId,
     rootLayerId,
     selectedBlock,
-    selectedLayer: selected?.type === "layer" ? selected.layerId : undefined,
-    selectedWidgetId: selected?.type === "widget" ? selected.widgetId : undefined,
+    selected,
     teamId: team?.id,
   });
 

--- a/src/components/organisms/EarthEditor/PropertyPane/hooks.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 
 import {
   useChangePropertyValueMutation,
@@ -39,20 +39,13 @@ export type FieldPointer = {
 };
 
 export default (mode: Mode) => {
-  const [selected] = useSelected();
+  const [selected, select] = useSelected();
   const [selectedBlock, selectBlock] = useSelectedBlock();
   const [rootLayerId] = useRootLayerId();
   const [isCapturing, onIsCapturingChange] = useIsCapturing();
   const [camera, setCamera] = useCamera();
   const [team] = useTeam();
   const [sceneId] = useSceneId();
-
-  const selectedLayerId = selected?.type === "layer" ? selected.layerId : undefined;
-  const selectedWidgetId = useMemo(() => {
-    const wid = selected?.type === "widget" ? selected.widgetId : undefined;
-    const wids = wid?.split("/");
-    return wids?.length === 2 ? { pluginId: wids[0], extensionId: wids[1] } : undefined;
-  }, [selected]);
 
   const {
     loading,
@@ -63,7 +56,6 @@ export default (mode: Mode) => {
     linkedDatasetId,
     isInfoboxCreatable,
     datasetSchemas,
-    scene,
     layers,
     assets,
     selectedWidget,
@@ -73,7 +65,7 @@ export default (mode: Mode) => {
     rootLayerId,
     selectedBlock,
     selectedLayer: selected?.type === "layer" ? selected.layerId : undefined,
-    selectedWidgetId: selectedWidgetId,
+    selectedWidgetId: selected?.type === "widget" ? selected.widgetId : undefined,
     teamId: team?.id,
   });
 
@@ -196,28 +188,28 @@ export default (mode: Mode) => {
 
   const [createInfoboxMutation] = useCreateInfoboxMutation();
   const createInfobox = useCallback(() => {
-    if (!selectedLayerId) return;
+    if (selected?.type !== "layer") return;
     return createInfoboxMutation({
-      variables: { layerId: selectedLayerId },
+      variables: { layerId: selected.layerId },
     });
-  }, [createInfoboxMutation, selectedLayerId]);
+  }, [createInfoboxMutation, selected]);
 
   const [removeInfoboxMutation] = useRemoveInfoboxMutation();
   const removeInfobox = useCallback(() => {
-    if (!selectedLayerId) return;
+    if (selected?.type !== "layer") return;
     return removeInfoboxMutation({
-      variables: { layerId: selectedLayerId },
+      variables: { layerId: selected.layerId },
     });
-  }, [removeInfoboxMutation, selectedLayerId]);
+  }, [removeInfoboxMutation, selected]);
 
   const [removeInfoboxFieldMutation] = useRemoveInfoboxFieldMutation();
   const removeInfoboxField = useCallback(() => {
-    if (!selectedBlock || !selectedLayerId) return;
+    if (!selectedBlock || selected?.type !== "layer") return;
     selectBlock(undefined);
     return removeInfoboxFieldMutation({
-      variables: { layerId: selectedLayerId, infoboxFieldId: selectedBlock },
+      variables: { layerId: selected.layerId, infoboxFieldId: selectedBlock },
     });
-  }, [removeInfoboxFieldMutation, selectBlock, selectedBlock, selectedLayerId]);
+  }, [removeInfoboxFieldMutation, selectBlock, selectedBlock, selected]);
 
   const onCameraChange = useCallback(
     (value: Partial<Camera>) => {
@@ -280,45 +272,46 @@ export default (mode: Mode) => {
 
   const onWidgetActivate = useCallback(
     async (enabled: boolean) => {
-      if (!sceneId || !selectedWidgetId) return;
+      if (!sceneId || selected?.type !== "widget") return;
       if (!enabled) {
+        if (!selected.widgetId) return;
         await updateWidgetMutation({
           variables: {
             sceneId,
-            pluginId: selectedWidgetId.pluginId,
-            extensionId: selectedWidgetId.extensionId,
+            widgetId: selected.widgetId,
             enabled: false,
           },
           refetchQueries: ["GetEarthWidgets"],
         });
-      } else if (
-        scene?.widgets.some(
-          w =>
-            w.pluginId === selectedWidgetId.pluginId &&
-            w.extensionId === selectedWidgetId.extensionId,
-        )
-      ) {
+      } else if (selected.widgetId) {
         await updateWidgetMutation({
           variables: {
             sceneId,
-            pluginId: selectedWidgetId.pluginId,
-            extensionId: selectedWidgetId.extensionId,
+            widgetId: selected.widgetId,
             enabled: true,
           },
           refetchQueries: ["GetEarthWidgets"],
         });
       } else {
-        await addWidgetMutation({
+        const { data } = await addWidgetMutation({
           variables: {
             sceneId,
-            pluginId: selectedWidgetId.pluginId,
-            extensionId: selectedWidgetId.extensionId,
+            pluginId: selected.pluginId,
+            extensionId: selected.extensionId,
           },
-          refetchQueries: ["GetEarthWidgets"],
+          refetchQueries: ["GetEarthWidgets", "GetWidgets"],
         });
+        if (data?.addWidget?.sceneWidget) {
+          select({
+            type: "widget",
+            widgetId: data.addWidget.sceneWidget.id,
+            pluginId: data.addWidget.sceneWidget.pluginId,
+            extensionId: data.addWidget.sceneWidget.extensionId,
+          });
+        }
       }
     },
-    [addWidgetMutation, scene?.widgets, sceneId, selectedWidgetId, updateWidgetMutation],
+    [addWidgetMutation, sceneId, select, selected, updateWidgetMutation],
   );
 
   const [updatePropertyItemsMutation] = useUpdatePropertyItemsMutation();

--- a/src/components/organisms/EarthEditor/PropertyPane/queries.ts
+++ b/src/components/organisms/EarthEditor/PropertyPane/queries.ts
@@ -392,13 +392,19 @@ export const ADD_WIDGET = gql`
           }
         }
       }
+      sceneWidget {
+        id
+        enabled
+        pluginId
+        extensionId
+      }
     }
   }
 `;
 
 export const REMOVE_WIDGET = gql`
-  mutation removeWidget($sceneId: ID!, $pluginId: PluginID!, $extensionId: PluginExtensionID!) {
-    removeWidget(input: { sceneId: $sceneId, pluginId: $pluginId, extensionId: $extensionId }) {
+  mutation removeWidget($sceneId: ID!, $widgetId: ID!) {
+    removeWidget(input: { sceneId: $sceneId, widgetId: $widgetId }) {
       scene {
         id
         widgets {
@@ -414,20 +420,8 @@ export const REMOVE_WIDGET = gql`
 `;
 
 export const UPDATE_WIDGET = gql`
-  mutation updateWidget(
-    $sceneId: ID!
-    $pluginId: PluginID!
-    $extensionId: PluginExtensionID!
-    $enabled: Boolean
-  ) {
-    updateWidget(
-      input: {
-        sceneId: $sceneId
-        pluginId: $pluginId
-        extensionId: $extensionId
-        enabled: $enabled
-      }
-    ) {
+  mutation updateWidget($sceneId: ID!, $widgetId: ID!, $enabled: Boolean) {
+    updateWidget(input: { sceneId: $sceneId, widgetId: $widgetId, enabled: $enabled }) {
       scene {
         id
         widgets {

--- a/src/gql/fragments/property.ts
+++ b/src/gql/fragments/property.ts
@@ -6,7 +6,7 @@ const propertyFragment = gql`
     title
     translatedTitle
     isList
-    name
+    representativeFieldId
     isAvailableIf {
       fieldId
       type
@@ -14,9 +14,9 @@ const propertyFragment = gql`
     }
     fields {
       fieldId
-      name
+      title
       description
-      translatedName
+      translatedTitle
       translatedDescription
       prefix
       suffix
@@ -27,9 +27,9 @@ const propertyFragment = gql`
       max
       choices {
         key
-        # icon
-        label
-        translatedLabel
+        icon
+        title
+        translatedTitle
       }
       isAvailableIf {
         fieldId

--- a/src/gql/graphql-client-api.tsx
+++ b/src/gql/graphql-client-api.tsx
@@ -179,12 +179,6 @@ export type Camera = {
   fov: Scalars['Float'];
 };
 
-export type CheckProjectAliasPayload = {
-  __typename?: 'CheckProjectAliasPayload';
-  alias: Scalars['String'];
-  available: Scalars['Boolean'];
-};
-
 export type CreateAssetInput = {
   teamId: Scalars['ID'];
   file: Scalars['Upload'];
@@ -656,13 +650,13 @@ export type Mutation = {
   updateProject?: Maybe<ProjectPayload>;
   publishProject?: Maybe<ProjectPayload>;
   deleteProject?: Maybe<DeleteProjectPayload>;
-  uploadPlugin?: Maybe<UploadPluginPayload>;
   createScene?: Maybe<CreateScenePayload>;
   addWidget?: Maybe<AddWidgetPayload>;
   updateWidget?: Maybe<UpdateWidgetPayload>;
   removeWidget?: Maybe<RemoveWidgetPayload>;
   installPlugin?: Maybe<InstallPluginPayload>;
   uninstallPlugin?: Maybe<UninstallPluginPayload>;
+  uploadPlugin?: Maybe<UploadPluginPayload>;
   upgradePlugin?: Maybe<UpgradePluginPayload>;
   updateDatasetSchema?: Maybe<UpdateDatasetSchemaPayload>;
   syncDataset?: Maybe<SyncDatasetPayload>;
@@ -673,10 +667,6 @@ export type Mutation = {
   importDatasetFromGoogleSheet?: Maybe<ImportDatasetPayload>;
   addDatasetSchema?: Maybe<AddDatasetSchemaPayload>;
   updatePropertyValue?: Maybe<PropertyFieldPayload>;
-  updatePropertyValueLatLng?: Maybe<PropertyFieldPayload>;
-  updatePropertyValueLatLngHeight?: Maybe<PropertyFieldPayload>;
-  updatePropertyValueCamera?: Maybe<PropertyFieldPayload>;
-  updatePropertyValueTypography?: Maybe<PropertyFieldPayload>;
   removePropertyField?: Maybe<PropertyFieldPayload>;
   uploadFileToProperty?: Maybe<PropertyFieldPayload>;
   linkDatasetToPropertyValue?: Maybe<PropertyFieldPayload>;
@@ -779,11 +769,6 @@ export type MutationDeleteProjectArgs = {
 };
 
 
-export type MutationUploadPluginArgs = {
-  input: UploadPluginInput;
-};
-
-
 export type MutationCreateSceneArgs = {
   input: CreateSceneInput;
 };
@@ -811,6 +796,11 @@ export type MutationInstallPluginArgs = {
 
 export type MutationUninstallPluginArgs = {
   input: UninstallPluginInput;
+};
+
+
+export type MutationUploadPluginArgs = {
+  input: UploadPluginInput;
 };
 
 
@@ -861,26 +851,6 @@ export type MutationAddDatasetSchemaArgs = {
 
 export type MutationUpdatePropertyValueArgs = {
   input: UpdatePropertyValueInput;
-};
-
-
-export type MutationUpdatePropertyValueLatLngArgs = {
-  input: UpdatePropertyValueLatLngInput;
-};
-
-
-export type MutationUpdatePropertyValueLatLngHeightArgs = {
-  input: UpdatePropertyValueLatLngHeightInput;
-};
-
-
-export type MutationUpdatePropertyValueCameraArgs = {
-  input: UpdatePropertyValueCameraInput;
-};
-
-
-export type MutationUpdatePropertyValueTypographyArgs = {
-  input: UpdatePropertyValueTypographyInput;
 };
 
 
@@ -983,6 +953,7 @@ export type Node = {
 };
 
 export enum NodeType {
+  Asset = 'ASSET',
   User = 'USER',
   Team = 'TEAM',
   Project = 'PROJECT',
@@ -1117,6 +1088,12 @@ export type Project = Node & {
   scene?: Maybe<Scene>;
 };
 
+export type ProjectAliasAvailability = {
+  __typename?: 'ProjectAliasAvailability';
+  alias: Scalars['String'];
+  available: Scalars['Boolean'];
+};
+
 export type ProjectConnection = {
   __typename?: 'ProjectConnection';
   edges: Array<ProjectEdge>;
@@ -1235,7 +1212,6 @@ export type PropertySchemaField = {
   fieldId: Scalars['PropertySchemaFieldID'];
   type: ValueType;
   title: Scalars['String'];
-  name: Scalars['String'];
   description: Scalars['String'];
   prefix?: Maybe<Scalars['String']>;
   suffix?: Maybe<Scalars['String']>;
@@ -1246,20 +1222,13 @@ export type PropertySchemaField = {
   choices?: Maybe<Array<PropertySchemaFieldChoice>>;
   isAvailableIf?: Maybe<PropertyCondition>;
   allTranslatedTitle?: Maybe<Scalars['TranslatedString']>;
-  allTranslatedName?: Maybe<Scalars['TranslatedString']>;
   allTranslatedDescription?: Maybe<Scalars['TranslatedString']>;
   translatedTitle: Scalars['String'];
-  translatedName: Scalars['String'];
   translatedDescription: Scalars['String'];
 };
 
 
 export type PropertySchemaFieldTranslatedTitleArgs = {
-  lang?: Maybe<Scalars['String']>;
-};
-
-
-export type PropertySchemaFieldTranslatedNameArgs = {
   lang?: Maybe<Scalars['String']>;
 };
 
@@ -1272,21 +1241,13 @@ export type PropertySchemaFieldChoice = {
   __typename?: 'PropertySchemaFieldChoice';
   key: Scalars['String'];
   title: Scalars['String'];
-  label: Scalars['String'];
   icon?: Maybe<Scalars['String']>;
   allTranslatedTitle?: Maybe<Scalars['TranslatedString']>;
-  allTranslatedLabel?: Maybe<Scalars['TranslatedString']>;
   translatedTitle: Scalars['String'];
-  translatedLabel: Scalars['String'];
 };
 
 
 export type PropertySchemaFieldChoiceTranslatedTitleArgs = {
-  lang?: Maybe<Scalars['String']>;
-};
-
-
-export type PropertySchemaFieldChoiceTranslatedLabelArgs = {
   lang?: Maybe<Scalars['String']>;
 };
 
@@ -1312,7 +1273,6 @@ export type PropertySchemaGroup = {
   isAvailableIf?: Maybe<PropertyCondition>;
   title?: Maybe<Scalars['String']>;
   allTranslatedTitle?: Maybe<Scalars['TranslatedString']>;
-  name?: Maybe<Scalars['PropertySchemaFieldID']>;
   representativeFieldId?: Maybe<Scalars['PropertySchemaFieldID']>;
   representativeField?: Maybe<PropertySchemaField>;
   schema?: Maybe<PropertySchema>;
@@ -1355,7 +1315,7 @@ export type Query = {
   sceneLock?: Maybe<SceneLockMode>;
   dynamicDatasetSchemas: Array<DatasetSchema>;
   searchUser?: Maybe<SearchedUser>;
-  checkProjectAlias: CheckProjectAliasPayload;
+  checkProjectAlias: ProjectAliasAvailability;
   installablePlugins: Array<PluginMetadata>;
 };
 
@@ -1544,15 +1504,13 @@ export type RemovePropertyItemInput = {
 
 export type RemoveWidgetInput = {
   sceneId: Scalars['ID'];
-  pluginId: Scalars['PluginID'];
-  extensionId: Scalars['PluginExtensionID'];
+  widgetId: Scalars['ID'];
 };
 
 export type RemoveWidgetPayload = {
   __typename?: 'RemoveWidgetPayload';
   scene: Scene;
-  pluginId: Scalars['PluginID'];
-  extensionId: Scalars['PluginExtensionID'];
+  widgetId: Scalars['ID'];
 };
 
 export enum Role {
@@ -1809,20 +1767,6 @@ export type UpdatePropertyItemOperationInput = {
   nameFieldType?: Maybe<ValueType>;
 };
 
-export type UpdatePropertyValueCameraInput = {
-  propertyId: Scalars['ID'];
-  schemaItemId?: Maybe<Scalars['PropertySchemaFieldID']>;
-  itemId?: Maybe<Scalars['ID']>;
-  fieldId: Scalars['PropertySchemaFieldID'];
-  lat: Scalars['Float'];
-  lng: Scalars['Float'];
-  altitude: Scalars['Float'];
-  heading: Scalars['Float'];
-  pitch: Scalars['Float'];
-  roll: Scalars['Float'];
-  fov: Scalars['Float'];
-};
-
 export type UpdatePropertyValueInput = {
   propertyId: Scalars['ID'];
   schemaItemId?: Maybe<Scalars['PropertySchemaFieldID']>;
@@ -1830,40 +1774,6 @@ export type UpdatePropertyValueInput = {
   fieldId: Scalars['PropertySchemaFieldID'];
   value?: Maybe<Scalars['Any']>;
   type: ValueType;
-};
-
-export type UpdatePropertyValueLatLngHeightInput = {
-  propertyId: Scalars['ID'];
-  schemaItemId?: Maybe<Scalars['PropertySchemaFieldID']>;
-  itemId?: Maybe<Scalars['ID']>;
-  fieldId: Scalars['PropertySchemaFieldID'];
-  lat: Scalars['Float'];
-  lng: Scalars['Float'];
-  height: Scalars['Float'];
-};
-
-export type UpdatePropertyValueLatLngInput = {
-  propertyId: Scalars['ID'];
-  schemaItemId?: Maybe<Scalars['PropertySchemaFieldID']>;
-  itemId?: Maybe<Scalars['ID']>;
-  fieldId: Scalars['PropertySchemaFieldID'];
-  lat: Scalars['Float'];
-  lng: Scalars['Float'];
-};
-
-export type UpdatePropertyValueTypographyInput = {
-  propertyId: Scalars['ID'];
-  schemaItemId?: Maybe<Scalars['PropertySchemaFieldID']>;
-  itemId?: Maybe<Scalars['ID']>;
-  fieldId: Scalars['PropertySchemaFieldID'];
-  fontFamily?: Maybe<Scalars['String']>;
-  fontWeight?: Maybe<Scalars['String']>;
-  fontSize?: Maybe<Scalars['Int']>;
-  color?: Maybe<Scalars['String']>;
-  textAlign?: Maybe<TextAlign>;
-  bold?: Maybe<Scalars['Boolean']>;
-  italic?: Maybe<Scalars['Boolean']>;
-  underline?: Maybe<Scalars['Boolean']>;
 };
 
 export type UpdateTeamInput = {
@@ -1878,8 +1788,7 @@ export type UpdateTeamPayload = {
 
 export type UpdateWidgetInput = {
   sceneId: Scalars['ID'];
-  pluginId: Scalars['PluginID'];
-  extensionId: Scalars['PluginExtensionID'];
+  widgetId: Scalars['ID'];
   enabled?: Maybe<Scalars['Boolean']>;
 };
 
@@ -2690,8 +2599,8 @@ export type CheckProjectAliasQueryVariables = Exact<{
 export type CheckProjectAliasQuery = (
   { __typename?: 'Query' }
   & { checkProjectAlias: (
-    { __typename?: 'CheckProjectAliasPayload' }
-    & Pick<CheckProjectAliasPayload, 'alias' | 'available'>
+    { __typename?: 'ProjectAliasAvailability' }
+    & Pick<ProjectAliasAvailability, 'alias' | 'available'>
   ) }
 );
 
@@ -3550,14 +3459,16 @@ export type AddWidgetMutation = (
           & PropertyFragmentFragment
         )> }
       )> }
+    ), sceneWidget: (
+      { __typename?: 'SceneWidget' }
+      & Pick<SceneWidget, 'id' | 'enabled' | 'pluginId' | 'extensionId'>
     ) }
   )> }
 );
 
 export type RemoveWidgetMutationVariables = Exact<{
   sceneId: Scalars['ID'];
-  pluginId: Scalars['PluginID'];
-  extensionId: Scalars['PluginExtensionID'];
+  widgetId: Scalars['ID'];
 }>;
 
 
@@ -3578,8 +3489,7 @@ export type RemoveWidgetMutation = (
 
 export type UpdateWidgetMutationVariables = Exact<{
   sceneId: Scalars['ID'];
-  pluginId: Scalars['PluginID'];
-  extensionId: Scalars['PluginExtensionID'];
+  widgetId: Scalars['ID'];
   enabled?: Maybe<Scalars['Boolean']>;
 }>;
 
@@ -4401,16 +4311,16 @@ export type Layer5FragmentFragment = Layer5Fragment_LayerGroup_Fragment | Layer5
 
 export type PropertySchemaItemFragmentFragment = (
   { __typename?: 'PropertySchemaGroup' }
-  & Pick<PropertySchemaGroup, 'schemaGroupId' | 'title' | 'translatedTitle' | 'isList' | 'name'>
+  & Pick<PropertySchemaGroup, 'schemaGroupId' | 'title' | 'translatedTitle' | 'isList' | 'representativeFieldId'>
   & { isAvailableIf?: Maybe<(
     { __typename?: 'PropertyCondition' }
     & Pick<PropertyCondition, 'fieldId' | 'type' | 'value'>
   )>, fields: Array<(
     { __typename?: 'PropertySchemaField' }
-    & Pick<PropertySchemaField, 'fieldId' | 'name' | 'description' | 'translatedName' | 'translatedDescription' | 'prefix' | 'suffix' | 'type' | 'defaultValue' | 'ui' | 'min' | 'max'>
+    & Pick<PropertySchemaField, 'fieldId' | 'title' | 'description' | 'translatedTitle' | 'translatedDescription' | 'prefix' | 'suffix' | 'type' | 'defaultValue' | 'ui' | 'min' | 'max'>
     & { choices?: Maybe<Array<(
       { __typename?: 'PropertySchemaFieldChoice' }
-      & Pick<PropertySchemaFieldChoice, 'key' | 'label' | 'translatedLabel'>
+      & Pick<PropertySchemaFieldChoice, 'key' | 'icon' | 'title' | 'translatedTitle'>
     )>>, isAvailableIf?: Maybe<(
       { __typename?: 'PropertyCondition' }
       & Pick<PropertyCondition, 'fieldId' | 'type' | 'value'>
@@ -4682,7 +4592,7 @@ export const PropertySchemaItemFragmentFragmentDoc = gql`
   title
   translatedTitle
   isList
-  name
+  representativeFieldId
   isAvailableIf {
     fieldId
     type
@@ -4690,9 +4600,9 @@ export const PropertySchemaItemFragmentFragmentDoc = gql`
   }
   fields {
     fieldId
-    name
+    title
     description
-    translatedName
+    translatedTitle
     translatedDescription
     prefix
     suffix
@@ -4703,8 +4613,9 @@ export const PropertySchemaItemFragmentFragmentDoc = gql`
     max
     choices {
       key
-      label
-      translatedLabel
+      icon
+      title
+      translatedTitle
     }
     isAvailableIf {
       fieldId
@@ -7072,6 +6983,12 @@ export const AddWidgetDocument = gql`
         }
       }
     }
+    sceneWidget {
+      id
+      enabled
+      pluginId
+      extensionId
+    }
   }
 }
     ${PropertyFragmentFragmentDoc}`;
@@ -7103,10 +7020,8 @@ export type AddWidgetMutationHookResult = ReturnType<typeof useAddWidgetMutation
 export type AddWidgetMutationResult = Apollo.MutationResult<AddWidgetMutation>;
 export type AddWidgetMutationOptions = Apollo.BaseMutationOptions<AddWidgetMutation, AddWidgetMutationVariables>;
 export const RemoveWidgetDocument = gql`
-    mutation removeWidget($sceneId: ID!, $pluginId: PluginID!, $extensionId: PluginExtensionID!) {
-  removeWidget(
-    input: {sceneId: $sceneId, pluginId: $pluginId, extensionId: $extensionId}
-  ) {
+    mutation removeWidget($sceneId: ID!, $widgetId: ID!) {
+  removeWidget(input: {sceneId: $sceneId, widgetId: $widgetId}) {
     scene {
       id
       widgets {
@@ -7136,8 +7051,7 @@ export type RemoveWidgetMutationFn = Apollo.MutationFunction<RemoveWidgetMutatio
  * const [removeWidgetMutation, { data, loading, error }] = useRemoveWidgetMutation({
  *   variables: {
  *      sceneId: // value for 'sceneId'
- *      pluginId: // value for 'pluginId'
- *      extensionId: // value for 'extensionId'
+ *      widgetId: // value for 'widgetId'
  *   },
  * });
  */
@@ -7148,10 +7062,8 @@ export type RemoveWidgetMutationHookResult = ReturnType<typeof useRemoveWidgetMu
 export type RemoveWidgetMutationResult = Apollo.MutationResult<RemoveWidgetMutation>;
 export type RemoveWidgetMutationOptions = Apollo.BaseMutationOptions<RemoveWidgetMutation, RemoveWidgetMutationVariables>;
 export const UpdateWidgetDocument = gql`
-    mutation updateWidget($sceneId: ID!, $pluginId: PluginID!, $extensionId: PluginExtensionID!, $enabled: Boolean) {
-  updateWidget(
-    input: {sceneId: $sceneId, pluginId: $pluginId, extensionId: $extensionId, enabled: $enabled}
-  ) {
+    mutation updateWidget($sceneId: ID!, $widgetId: ID!, $enabled: Boolean) {
+  updateWidget(input: {sceneId: $sceneId, widgetId: $widgetId, enabled: $enabled}) {
     scene {
       id
       widgets {
@@ -7181,8 +7093,7 @@ export type UpdateWidgetMutationFn = Apollo.MutationFunction<UpdateWidgetMutatio
  * const [updateWidgetMutation, { data, loading, error }] = useUpdateWidgetMutation({
  *   variables: {
  *      sceneId: // value for 'sceneId'
- *      pluginId: // value for 'pluginId'
- *      extensionId: // value for 'extensionId'
+ *      widgetId: // value for 'widgetId'
  *      enabled: // value for 'enabled'
  *   },
  * });

--- a/src/gql/graphql.schema.json
+++ b/src/gql/graphql.schema.json
@@ -1404,59 +1404,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "CheckProjectAliasPayload",
-        "description": null,
-        "fields": [
-          {
-            "name": "alias",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "available",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Boolean",
-        "description": "The `Boolean` scalar type represents `true` or `false`.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "CreateAssetInput",
         "description": null,
@@ -1679,6 +1626,16 @@
             "deprecationReason": null
           }
         ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "fields": null,
+        "inputFields": null,
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
@@ -6288,35 +6245,6 @@
             "deprecationReason": null
           },
           {
-            "name": "uploadPlugin",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UploadPluginInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "UploadPluginPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "createScene",
             "description": null,
             "args": [
@@ -6485,6 +6413,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "UninstallPluginPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uploadPlugin",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UploadPluginInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UploadPluginPayload",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6764,122 +6721,6 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "UpdatePropertyValueInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PropertyFieldPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatePropertyValueLatLng",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UpdatePropertyValueLatLngInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PropertyFieldPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatePropertyValueLatLngHeight",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UpdatePropertyValueLatLngHeightInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PropertyFieldPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatePropertyValueCamera",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UpdatePropertyValueCameraInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PropertyFieldPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatePropertyValueTypography",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UpdatePropertyValueTypographyInput",
                     "ofType": null
                   }
                 },
@@ -7534,6 +7375,12 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
+          {
+            "name": "ASSET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "USER",
             "description": null,
@@ -8721,6 +8568,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ProjectAliasAvailability",
+        "description": null,
+        "fields": [
+          {
+            "name": "alias",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "available",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ProjectConnection",
         "description": null,
         "fields": [
@@ -9831,22 +9721,6 @@
             "deprecationReason": null
           },
           {
-            "name": "name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "description",
             "description": null,
             "args": [],
@@ -9979,18 +9853,6 @@
             "deprecationReason": null
           },
           {
-            "name": "allTranslatedName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "TranslatedString",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "allTranslatedDescription",
             "description": null,
             "args": [],
@@ -10004,35 +9866,6 @@
           },
           {
             "name": "translatedTitle",
-            "description": null,
-            "args": [
-              {
-                "name": "lang",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "translatedName",
             "description": null,
             "args": [
               {
@@ -10133,22 +9966,6 @@
             "deprecationReason": null
           },
           {
-            "name": "label",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "icon",
             "description": null,
             "args": [],
@@ -10173,48 +9990,7 @@
             "deprecationReason": null
           },
           {
-            "name": "allTranslatedLabel",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "TranslatedString",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "translatedTitle",
-            "description": null,
-            "args": [
-              {
-                "name": "lang",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "translatedLabel",
             "description": null,
             "args": [
               {
@@ -10431,18 +10207,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "TranslatedString",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "PropertySchemaFieldID",
               "ofType": null
             },
             "isDeprecated": false,
@@ -11411,7 +11175,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "CheckProjectAliasPayload",
+                "name": "ProjectAliasAvailability",
                 "ofType": null
               }
             },
@@ -12099,30 +11863,14 @@
             "deprecationReason": null
           },
           {
-            "name": "pluginId",
+            "name": "widgetId",
             "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "PluginID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "extensionId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PluginExtensionID",
+                "name": "ID",
                 "ofType": null
               }
             },
@@ -12157,7 +11905,7 @@
             "deprecationReason": null
           },
           {
-            "name": "pluginId",
+            "name": "widgetId",
             "description": null,
             "args": [],
             "type": {
@@ -12165,23 +11913,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "PluginID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "extensionId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PluginExtensionID",
+                "name": "ID",
                 "ofType": null
               }
             },
@@ -14406,185 +14138,6 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "UpdatePropertyValueCameraInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "propertyId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "schemaItemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "PropertySchemaFieldID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "itemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fieldId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PropertySchemaFieldID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lat",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lng",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "altitude",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "heading",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pitch",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "roll",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fov",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
         "name": "UpdatePropertyValueInput",
         "description": null,
         "fields": null,
@@ -14668,383 +14221,6 @@
                 "name": "ValueType",
                 "ofType": null
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "UpdatePropertyValueLatLngHeightInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "propertyId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "schemaItemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "PropertySchemaFieldID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "itemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fieldId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PropertySchemaFieldID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lat",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lng",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "height",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "UpdatePropertyValueLatLngInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "propertyId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "schemaItemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "PropertySchemaFieldID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "itemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fieldId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PropertySchemaFieldID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lat",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lng",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "UpdatePropertyValueTypographyInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "propertyId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "schemaItemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "PropertySchemaFieldID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "itemId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fieldId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PropertySchemaFieldID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fontFamily",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fontWeight",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fontSize",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "color",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "textAlign",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "TextAlign",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "bold",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "italic",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "underline",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -15148,30 +14324,14 @@
             "deprecationReason": null
           },
           {
-            "name": "pluginId",
+            "name": "widgetId",
             "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "PluginID",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "extensionId",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "PluginExtensionID",
+                "name": "ID",
                 "ofType": null
               }
             },

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -14,7 +14,7 @@ export const useRootLayerId = () => useAtom(rootLayerId);
 export type Selected =
   | { type: "scene" }
   | { type: "layer"; layerId: string }
-  | { type: "widget"; widgetId?: string };
+  | { type: "widget"; widgetId?: string; pluginId: string; extensionId: string };
 const selected = atom<Selected | undefined>(undefined);
 export const useSelected = () => useAtom(selected);
 


### PR DESCRIPTION
# Overview

## What I've done

Follow https://github.com/reearth/reearth-backend/pull/43 's change:

- Replace deprecated fields in queries
- Change input of widget mutation

No UI changes

## How I tested

Manually tested
