### PR TITLE
fix: password updating

### DIFF
--- a/src/components/atoms/TextBox/index.tsx
+++ b/src/components/atoms/TextBox/index.tsx
@@ -9,6 +9,7 @@ export type Props = {
   value?: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  type?: "text" | "password";
   multiline?: boolean;
   prefix?: string;
   suffix?: string;
@@ -25,9 +26,10 @@ export type Props = {
 const TextBox: React.FC<Props> = ({
   className,
   value,
-  multiline,
-  disabled,
   onChange,
+  disabled,
+  type = "text",
+  multiline,
   prefix,
   suffix,
   placeholder,
@@ -125,6 +127,7 @@ const TextBox: React.FC<Props> = ({
           onKeyPress={handleKeyPress}
           onBlur={handleBlur}
           color={color}
+          type={type}
           backgroundColor={backgroundColor}
           disabled={disabled}
           placeholder={placeholder}

--- a/src/components/molecules/Settings/Account/AccountSection/index.tsx
+++ b/src/components/molecules/Settings/Account/AccountSection/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import PasswordModal from "@reearth/components/molecules/Settings/Account/PasswordModal";
 import Section from "@reearth/components/molecules/Settings/Section";
 import EditableItem from "@reearth/components/molecules/Settings/Project/EditableItem";
@@ -8,6 +8,8 @@ import { styled } from "@reearth/theme";
 import { useIntl } from "react-intl";
 import Text from "@reearth/components/atoms/Text";
 import Flex from "@reearth/components/atoms/Flex";
+
+export type Theme = "DARK" | "LIGHT";
 
 export type Props = {
   email?: string;
@@ -34,22 +36,32 @@ const ProfileSection: React.FC<Props> = ({
 }) => {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState(false);
-  const [currentLang, setCurrentLang] = useState<string>();
-  const [currentThemeLabel, setCurrentThemeLabel] = useState<string>();
-  type Theme = "DARK" | "LIGHT";
-  const themeItems: { key: Theme; label: string; icon: string }[] = [
-    { key: "DARK", label: intl.formatMessage({ defaultMessage: "Dark theme" }), icon: "moon" },
-    { key: "LIGHT", label: intl.formatMessage({ defaultMessage: "Light theme" }), icon: "sun" },
-  ];
-  useEffect(() => {
-    const lang = items.find(item => item.key === intl.locale);
-    setCurrentLang(lang?.label);
-  }, [intl.locale]);
 
-  useEffect(() => {
-    const label = themeItems.find(themeItem => themeItem.key === appTheme)?.label;
-    setCurrentThemeLabel(label);
-  }, [appTheme]);
+  const themeItems: { key: Theme; label: string; icon: string }[] = useMemo(
+    () => [
+      { key: "DARK", label: intl.formatMessage({ defaultMessage: "Dark theme" }), icon: "moon" },
+      { key: "LIGHT", label: intl.formatMessage({ defaultMessage: "Light theme" }), icon: "sun" },
+    ],
+    [intl],
+  );
+
+  const currentThemeLabel = useMemo(
+    () => themeItems.find(themeItem => themeItem.key === appTheme)?.label,
+    [appTheme, themeItems],
+  );
+
+  const currentLang = useMemo(
+    () => items.find(item => item.key === intl.locale)?.label,
+    [intl.locale],
+  );
+
+  const handleUpdatePassword = useCallback(
+    (password: string, passwordConfirmation: string) => {
+      updatePassword?.(password, passwordConfirmation);
+      setIsOpen(false);
+    },
+    [updatePassword],
+  );
 
   return (
     <Wrapper>
@@ -90,7 +102,7 @@ const ProfileSection: React.FC<Props> = ({
       </Section>
       <PasswordModal
         hasPassword={hasPassword}
-        updatePassword={updatePassword}
+        updatePassword={handleUpdatePassword}
         isVisible={isOpen}
         onClose={() => setIsOpen(false)}
       />

--- a/src/components/molecules/Settings/Account/PasswordModal/index.tsx
+++ b/src/components/molecules/Settings/Account/PasswordModal/index.tsx
@@ -27,17 +27,24 @@ type Props = {
 
 const PasswordModal: React.FC<Props> = ({ isVisible, onClose, hasPassword, updatePassword }) => {
   const intl = useIntl();
+  const theme = useTheme();
 
-  const [currentPassword, setCurrentPassword] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
   const [disabled, setDisabled] = useState(true);
 
+  const handleClose = useCallback(() => {
+    setPassword("");
+    setPasswordConfirmation("");
+    onClose?.();
+  }, [onClose]);
+
   const save = useCallback(() => {
     if (password === passwordConfirmation) {
-      updatePassword?.(currentPassword, passwordConfirmation);
+      updatePassword?.(password, passwordConfirmation);
+      handleClose();
     }
-  }, [updatePassword, password, currentPassword, passwordConfirmation]);
+  }, [updatePassword, handleClose, password, passwordConfirmation]);
 
   useEffect(() => {
     if (password !== passwordConfirmation || password === "" || passwordConfirmation === "") {
@@ -46,14 +53,6 @@ const PasswordModal: React.FC<Props> = ({ isVisible, onClose, hasPassword, updat
       setDisabled(false);
     }
   }, [password, passwordConfirmation]);
-
-  const handleClose = useCallback(() => {
-    setCurrentPassword("");
-    setPassword("");
-    setPasswordConfirmation("");
-    onClose?.();
-  }, [onClose]);
-  const theme = useTheme();
 
   return (
     <Modal
@@ -95,12 +94,6 @@ const PasswordModal: React.FC<Props> = ({ isVisible, onClose, hasPassword, updat
               </li>
             </StyledList>
           </Text>
-          <Label size="s">{intl.formatMessage({ defaultMessage: "Old password" })}</Label>
-          <StyledTextBox
-            borderColor={"#3f3d45"}
-            value={currentPassword}
-            onChange={setCurrentPassword}
-          />
           <Label size="s">
             {intl.formatMessage({ defaultMessage: "New password" })}
             {/* {intl.formatMessage({
@@ -108,11 +101,17 @@ const PasswordModal: React.FC<Props> = ({ isVisible, onClose, hasPassword, updat
                   "8 characters or more, 2 types or more from numbers, lowercase letters, uppercase letters",
               })} */}
           </Label>
-          <StyledTextBox borderColor={"#3f3d45"} value={password} onChange={setPassword} />
+          <StyledTextBox
+            type="password"
+            borderColor={"#3f3d45"}
+            value={password}
+            onChange={setPassword}
+          />
           <Label size="s">
             {intl.formatMessage({ defaultMessage: "New password (for confirmation)" })}
           </Label>
           <StyledTextBox
+            type="password"
             borderColor={"#3f3d45"}
             value={passwordConfirmation}
             onChange={setPasswordConfirmation}
@@ -122,6 +121,7 @@ const PasswordModal: React.FC<Props> = ({ isVisible, onClose, hasPassword, updat
         <div>
           <Label size="s">{intl.formatMessage({ defaultMessage: "New password" })}</Label>
           <StyledTextBox
+            type="password"
             borderColor={"#3f3d45"}
             value={passwordConfirmation}
             onChange={setPasswordConfirmation}

--- a/src/components/molecules/Settings/Project/EditableItem/index.tsx
+++ b/src/components/molecules/Settings/Project/EditableItem/index.tsx
@@ -47,7 +47,7 @@ const EditableItem: React.FC<Props> = ({
   onEditCancel,
 }) => {
   const [isEditting, setIsEditting] = useState(false);
-  const [inputState, setInputState] = useState(body || currentItem);
+  const [inputState, setInputState] = useState(currentItem || body);
 
   const startEdit = useCallback(() => {
     if (onEditStart) {
@@ -56,6 +56,7 @@ const EditableItem: React.FC<Props> = ({
       setIsEditting(true);
     }
   }, [setIsEditting, onEditStart]);
+
   const cancelEdit = useCallback(() => {
     if (onEditCancel) {
       onEditCancel();


### PR DESCRIPTION
# Overview
Users were unable to change their password

## What I've done
The frontend's handling of updating the password was wrong. We were sending to the backend the old password and the new password confirmation. We should send the new password and confirmation only. 
Anyways the user doesn't need to input their old password bc they are authenticated. 
Also found a warning in AccountSection so cleaned up that component.
Added type prop to TextBox so we could use it for passwords and hide the inputted characters.

## How I tested
- Changed my own password on local multiple times
