### PR TITLE
fix: language change not updating

### DIFF
--- a/src/components/organisms/Settings/Account/hooks.ts
+++ b/src/components/organisms/Settings/Account/hooks.ts
@@ -1,3 +1,4 @@
+import { useApolloClient } from "@apollo/client";
 import { useCallback } from "react";
 
 import { useUpdateMeMutation, useProfileQuery } from "@reearth/gql";
@@ -10,6 +11,7 @@ export enum Theme {
 }
 
 export default () => {
+  const client = useApolloClient();
   const [currentTeam] = useTeam();
   const [currentProject] = useProject();
 
@@ -35,10 +37,11 @@ export default () => {
   );
 
   const updateLanguage = useCallback(
-    (lang: string) => {
-      updateMeMutation({ variables: { lang } });
+    async (lang: string) => {
+      await updateMeMutation({ variables: { lang } });
+      await client.resetStore();
     },
-    [updateMeMutation],
+    [updateMeMutation, client],
   );
 
   const updateTheme = useCallback(


### PR DESCRIPTION
# Overview
Some parts of the UI wouldn't update after the language was changed. In particular the right panel when navigating from the Account Settings back to the Earth Editor.

## What I've done
Since the right panel's fields come from the backend and are stored in cache, after language is changed the apollo cache is reset so any possible translations coming from the backend will be fetched again with the new language.