### PR TITLE
fix: showing members section for personal workspace

### DIFF
--- a/src/components/organisms/Dashboard/hooks.ts
+++ b/src/components/organisms/Dashboard/hooks.ts
@@ -44,12 +44,16 @@ export default (teamId?: string) => {
 
   const teams = data?.me?.teams;
   const team = teams?.find(team => team.id === teamId);
+  const personal = teamId === data?.me?.myTeam.id;
 
   useEffect(() => {
     if (team?.id && team.id !== currentTeam?.id) {
-      setCurrentTeam(team);
+      setCurrentTeam({
+        personal,
+        ...team,
+      });
     }
-  }, [currentTeam, team, setCurrentTeam]);
+  }, [currentTeam, team, setCurrentTeam, personal]);
 
   const changeTeam = useCallback(
     (teamId: string) => {

--- a/src/components/organisms/EarthEditor/Header/hooks.ts
+++ b/src/components/organisms/EarthEditor/Header/hooks.ts
@@ -85,11 +85,7 @@ export default () => {
     const team = teams?.find(t => t.id === teamId);
     if (!team) return;
 
-    setTeam({
-      id: team.id,
-      name: team.name,
-      personal: team.personal,
-    });
+    setTeam(team);
   }, [teams, currentTeam, teamId, setTeam]);
 
   useEffect(() => {

--- a/src/components/organisms/EarthEditor/Header/hooks.ts
+++ b/src/components/organisms/EarthEditor/Header/hooks.ts
@@ -88,6 +88,7 @@ export default () => {
     setTeam({
       id: team.id,
       name: team.name,
+      personal: team.personal,
     });
   }, [teams, currentTeam, teamId, setTeam]);
 

--- a/src/components/organisms/Settings/SettingPage/hooks.ts
+++ b/src/components/organisms/Settings/SettingPage/hooks.ts
@@ -55,32 +55,11 @@ export default (params: Params) => {
   const team = teams?.find(team => team.id === teamId);
 
   useEffect(() => {
-    if (!currentTeam && teamsData?.me) {
-      const { id, name = "" } = teamId
-        ? teams?.find(t => t.id === teamId) ?? {}
-        : teamsData.me.myTeam;
-      if (id) {
-        setTeam({ id, name });
-      }
+    if (!currentTeam) {
+      setTeam(teamId ? teams?.find(t => t.id === teamId) : teamsData?.me?.myTeam ?? undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTeam, team, setTeam, teams, teamsData?.me]);
-
-  // update team name
-  useEffect(() => {
-    if (currentTeam?.id && teams) {
-      const { name = "" } = teams?.find(t => t.id === currentTeam.id) ?? {};
-      if (currentTeam.name != name) {
-        setTeam({ id: currentTeam.id, name });
-      }
-    }
-  }, [currentTeam, setTeam, teams]);
-
-  useEffect(() => {
-    if (team?.id && !currentTeam?.id) {
-      setTeam(team);
-    }
-  }, [currentTeam, team, setTeam]);
 
   const { data } = useProjectQuery({
     variables: { teamId: teamId ?? "" },

--- a/src/components/organisms/Settings/SettingPage/hooks.ts
+++ b/src/components/organisms/Settings/SettingPage/hooks.ts
@@ -52,14 +52,13 @@ export default (params: Params) => {
     name: teamsData?.me?.name ?? "",
   };
   const teams = teamsData?.me?.teams;
-  const team = teams?.find(team => team.id === teamId);
 
   useEffect(() => {
     if (!currentTeam) {
       setTeam(teamId ? teams?.find(t => t.id === teamId) : teamsData?.me?.myTeam ?? undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentTeam, team, setTeam, teams, teamsData?.me]);
+  }, [currentTeam, setTeam, teams, teamsData?.me]);
 
   const { data } = useProjectQuery({
     variables: { teamId: teamId ?? "" },

--- a/src/components/organisms/Settings/Workspace/hooks.ts
+++ b/src/components/organisms/Settings/Workspace/hooks.ts
@@ -77,8 +77,13 @@ export default (params: Params) => {
   const [updateTeamMutation] = useUpdateTeamMutation();
 
   const updateName = useCallback(
-    (name: string) => teamId && updateTeamMutation({ variables: { teamId, name } }),
-    [teamId, updateTeamMutation],
+    async (name: string) => {
+      if (teamId) {
+        const results = await updateTeamMutation({ variables: { teamId, name } });
+        setTeam(results.data?.updateTeam?.team);
+      }
+    },
+    [teamId, updateTeamMutation, setTeam],
   );
 
   const [deleteTeamMutation] = useDeleteTeamMutation({


### PR DESCRIPTION
# Overview
Had an issue where a personal workspace showed the members section when it shouldn't be rendered (personal workspace's only member is you, so no need).

## What I've done
- Cleanup code around updating team state
- fix where personal workspace page showed members section

## What I haven't done

## How I tested
- In the Dashboard, change to different workspace from header. Change back to personal workspace. Select "Manage workspaces". Click on workspace from left navigation. Should not show members section.
