### PR TITLE
fix: layers disappearing when in nested folders

### DIFF
--- a/src/components/molecules/Visualizer/Layers/store.ts
+++ b/src/components/molecules/Visualizer/Layers/store.ts
@@ -72,13 +72,16 @@ export class LayerStore {
 }
 
 function flattenLayers(layers: Layer[] | undefined): Layer[] {
-  const cb = (a: Layer[], b: Layer): Layer[] => [
-    ...a,
-    b,
-    ...(b.isVisible ? b.children?.reduce(cb, []) ?? [] : []),
-  ];
-
-  return layers?.reduce<Layer[]>(cb, []) ?? [];
+  return (
+    layers?.reduce<Layer[]>(
+      (a: Layer[], b: Layer): Layer[] => [
+        ...a,
+        b,
+        ...(b.isVisible ? flattenLayers(b.children) ?? [] : []),
+      ],
+      [],
+    ) ?? []
+  );
 }
 
 export const empty = new LayerStore({ id: "" });


### PR DESCRIPTION
Fixes an issue where all markers inside a nested folder (folder within a folder, or deeper) stopped displaying on cesium.
Also affected was marker information in Storytelling. Storytelling showed blanks which were broken (if selected nothing would happen, or if cycling through the layers, would break the flow and be completely back to 0)