### PR TITLE
fix: password policy conversion in config

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,7 +10,6 @@ test("convert password policy to regular expression", () => {
   expect(actual).toStrictEqual({
     whiteSpace: /(?=.*\s)/,
     highSecurity: /^(?=.*[a-z])(?=.*[A-Z])((?=(.*\d){2}))/,
-    wrong: undefined,
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export function convertPasswordPolicy(passwordPolicy?: {
           return [k, undefined];
         }
       })
-      .filter(Boolean),
+      .filter(i => !!i[1]),
   );
 }
 


### PR DESCRIPTION
Fixes a problem in how the config file's password policy is converted from string to RegExp. Helped by @rot1024 