### PR TITLE
chore: load local reearth-config.json for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __screenshots__
 /cypress/videos
 /cypress/screenshots
 /.env*
+/reearth-config.json

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,14 @@ const webpack = require("webpack");
 
 const pkg = require("./package.json");
 
+let reearthConfig = {};
+try {
+  // eslint-disable-next-line node/no-missing-require
+  reearthConfig = require("./reearth-config.json");
+} catch {
+  // ignore
+}
+
 module.exports = (env, args = {}) => {
   const isProd = args.mode === "production";
   const envfile = loadEnv(Object.keys(env || {}).find(k => !k.startsWith("WEBPACK_")));
@@ -28,6 +36,7 @@ module.exports = (env, args = {}) => {
         ...process.env,
       },
     }),
+    ...reearthConfig,
   };
 
   return {


### PR DESCRIPTION
`.env` is poor to represent nested and complrex objects, so now `reearth-config.json` will be automatically loaded if it exists on `yarn start`.