### PR TITLE
fix: minimized infobox's icons not showing

### DIFF
--- a/src/components/molecules/Visualizer/Infobox/Frame/index.tsx
+++ b/src/components/molecules/Visualizer/Infobox/Frame/index.tsx
@@ -102,7 +102,7 @@ const InfoBox: React.FC<Props> = ({
       floated>
       <Wrapper ref={ref} open={open}>
         <TitleFlex flex="0 0 auto" direction="column" onClick={handleOpen}>
-          {!noContent && (
+          {!open && (
             <IconWrapper align="center" justify="space-around">
               <StyledIcon color={publishedTheme.mainIcon} icon="arrowLeft" size={16} open={open} />
               <StyledIcon color={publishedTheme.mainIcon} icon="infobox" size={24} open={open} />


### PR DESCRIPTION
If infobox had no content the icons wouldn't show when minimized.

Before:
<img width="168" alt="Screen Shot 2021-11-08 at 11 02 08" src="https://user-images.githubusercontent.com/34051327/140673105-e9ac831f-6440-4f4b-a450-89fb55ca71b9.png">

After:
<img width="172" alt="Screen Shot 2021-11-08 at 11 00 31" src="https://user-images.githubusercontent.com/34051327/140673129-58758518-c131-415c-9fee-c7d40230c5e4.png">


