### PR TITLE
fix: markdown background color is not transparent

### DIFF
--- a/src/components/atoms/Markdown/index.tsx
+++ b/src/components/atoms/Markdown/index.tsx
@@ -45,6 +45,7 @@ const Markdown: React.FC<Props> = ({
 };
 
 const Wrapper = styled.div<{ styles?: Typography; dark: boolean }>`
+  background-color: transparent;
   color: inherit;
   font-family: inherit;
   font-size: inherit;


### PR DESCRIPTION
Fix reearth/reearth#164