### PR TITLE
fix: mobile align system's icon in some browsers

### DIFF
--- a/src/components/molecules/Visualizer/WidgetAlignSystem/MobileZone.tsx
+++ b/src/components/molecules/Visualizer/WidgetAlignSystem/MobileZone.tsx
@@ -118,7 +118,7 @@ const Control = styled.div<{ leftIcon?: boolean; rightIcon?: boolean }>`
   flex: 1;
   display: flex;
   justify-content: ${({ leftIcon, rightIcon }) =>
-    leftIcon ? "start" : rightIcon ? "end" : undefined};
+    leftIcon ? "flex-start" : rightIcon ? "flex-end" : undefined};
   align-items: center;
   cursor: pointer;
   pointer-events: auto;


### PR DESCRIPTION
# Overview
Testing found that on some mobile browsers (iOS's Chrome and Safari) the right arrow icon in the navigation wouldn't align correctly to the right (end). Seems like this has to do with the "start", "end", etc simplified standard being set by W3C not being widely compatible yet within the CSS flex context.

NOTE: This bug can't be seen in desktop browsers (even using dev tools). Needs to be merged to check on actual devices.

Before:
![IMG_B61D4C1A4406-1](https://user-images.githubusercontent.com/34051327/141232287-56c8b5ee-82bb-4d70-b829-18352079a4da.jpeg)

After:
![image](https://user-images.githubusercontent.com/34051327/141232327-4ec744f7-4e8e-4fbc-9824-4122d8f4f609.png)

