### PR TITLE
feat: enhance terrain feature (type selection, exaggeration)

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -1,12 +1,4 @@
-import {
-  createWorldTerrain,
-  Color,
-  Entity,
-  Ion,
-  EllipsoidTerrainProvider,
-  Cesium3DTileFeature,
-  Cartesian3,
-} from "cesium";
+import { Color, Entity, Ion, Cesium3DTileFeature, Cartesian3 } from "cesium";
 import type { Viewer as CesiumViewer, ImageryProvider, TerrainProvider } from "cesium";
 import CesiumDnD, { Context } from "cesium-dnd";
 import { isEqual } from "lodash-es";
@@ -21,6 +13,7 @@ import type { SelectLayerOptions, Ref as EngineRef, SceneProperty } from "..";
 
 import { getCamera, isDraggable, isSelectable, layerIdField } from "./common";
 import imagery from "./imagery";
+import terrain from "./terrain";
 import useEngineRef from "./useEngineRef";
 import { convertCartesian3ToPosition } from "./utils";
 
@@ -82,9 +75,40 @@ export default ({
     setImageryLayers(newTiles);
   }, [property?.tiles ?? []]);
 
+  // terrain
+  const terrainProperty = useMemo(
+    () => ({
+      terrain: property?.terrain?.terrain || property?.default?.terrain,
+      terrainType: property?.terrain?.terrainType || property?.default?.terrainType,
+      terrainExaggeration:
+        property?.terrain?.terrainExaggeration || property?.default?.terrainExaggeration,
+      terrainExaggerationRelativeHeight:
+        property?.terrain?.terrainExaggerationRelativeHeight ||
+        property?.default?.terrainExaggerationRelativeHeight,
+      depthTestAgainstTerrain:
+        property?.terrain?.depthTestAgainstTerrain || property?.default?.depthTestAgainstTerrain,
+    }),
+    [
+      property?.default?.terrain,
+      property?.default?.terrainType,
+      property?.default?.terrainExaggeration,
+      property?.default?.terrainExaggerationRelativeHeight,
+      property?.default?.depthTestAgainstTerrain,
+      property?.terrain?.terrain,
+      property?.terrain?.terrainType,
+      property?.terrain?.terrainExaggeration,
+      property?.terrain?.terrainExaggerationRelativeHeight,
+      property?.terrain?.depthTestAgainstTerrain,
+    ],
+  );
+
   const terrainProvider = useMemo((): TerrainProvider | undefined => {
-    return property?.default?.terrain ? createWorldTerrain() : new EllipsoidTerrainProvider();
-  }, [property?.default?.terrain]);
+    return terrainProperty.terrain
+      ? terrainProperty.terrainType
+        ? terrain[terrainProperty.terrainType] || terrain.default
+        : terrain.cesium
+      : terrain.default;
+  }, [terrainProperty.terrain, terrainProperty.terrainType]);
 
   const backgroundColor = useMemo(
     () =>
@@ -242,6 +266,7 @@ export default ({
 
   return {
     terrainProvider,
+    terrainProperty,
     backgroundColor,
     imageryLayers,
     cesium,

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -32,17 +32,18 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     ready,
     children,
     selectedLayerId,
+    isLayerDraggable,
+    isLayerDragging,
     onLayerSelect,
     onCameraChange,
     onLayerDrag,
     onLayerDrop,
-    isLayerDraggable,
-    isLayerDragging,
   },
   ref,
 ) => {
   const {
     terrainProvider,
+    terrainProperty,
     backgroundColor,
     imageryLayers,
     cesium,
@@ -108,15 +109,15 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         <Sun show={property?.atmosphere?.enable_sun ?? true} />
         <SkyAtmosphere show={property?.atmosphere?.sky_atmosphere ?? true} />
         <Globe
-          terrainProvider={terrainProvider}
-          depthTestAgainstTerrain={!!property?.default?.depthTestAgainstTerrain}
           enableLighting={!!property?.atmosphere?.enable_lighting}
           showGroundAtmosphere={property?.atmosphere?.ground_atmosphere ?? true}
           atmosphereSaturationShift={property?.atmosphere?.surturation_shift}
           atmosphereHueShift={property?.atmosphere?.hue_shift}
           atmosphereBrightnessShift={property?.atmosphere?.brightness_shift}
-          terrainExaggeration={property?.default?.terrainExaggeration}
-          terrainExaggerationRelativeHeight={property?.default?.terrainExaggerationRelativeHeight}
+          terrainProvider={terrainProvider}
+          depthTestAgainstTerrain={!!terrainProperty.depthTestAgainstTerrain}
+          terrainExaggerationRelativeHeight={terrainProperty.terrainExaggerationRelativeHeight}
+          terrainExaggeration={terrainProperty.terrainExaggeration}
         />
         {imageryLayers?.map(([id, im, min, max]) => (
           <ImageryLayer

--- a/src/components/molecules/Visualizer/Engine/Cesium/terrain.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/terrain.ts
@@ -1,0 +1,13 @@
+import {
+  ArcGISTiledElevationTerrainProvider,
+  EllipsoidTerrainProvider,
+  createWorldTerrain,
+} from "cesium";
+
+export default {
+  default: new EllipsoidTerrainProvider(),
+  cesium: createWorldTerrain(),
+  arcgis: new ArcGISTiledElevationTerrainProvider({
+    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer",
+  }),
+};

--- a/src/components/molecules/Visualizer/Engine/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/index.tsx
@@ -22,6 +22,7 @@ export type SceneProperty = {
   default?: {
     camera?: Camera;
     terrain?: boolean;
+    terrainType?: "cesium" | "arcgis"; // default: cesium
     terrainExaggeration?: number; // default: 1
     terrainExaggerationRelativeHeight?: number; // default: 0
     depthTestAgainstTerrain?: boolean;
@@ -36,6 +37,13 @@ export type SceneProperty = {
     tile_maxLevel?: number;
     tile_minLevel?: number;
   }[];
+  terrain?: {
+    terrain?: boolean;
+    terrainType?: "cesium" | "arcgis"; // default: cesium
+    terrainExaggeration?: number; // default: 1
+    terrainExaggerationRelativeHeight?: number; // default: 0
+    depthTestAgainstTerrain?: boolean;
+  };
   atmosphere?: {
     enable_sun?: boolean;
     enable_lighting?: boolean;


### PR DESCRIPTION
Enhance terrain feature:

- Support selecting terrain type
   - Cesium World Terrain, ArcGIS Terrain
   - Default is cesium
- Support terrain exaggeration

Backend is already implemented by https://github.com/reearth/reearth-backend/commit/8693b4833399c06958bab2c553f19bd4e0341603 and https://github.com/reearth/reearth-backend/commit/5e3d253ea63f2aaa356d7af528fbb8556d4b40d8

![image](https://user-images.githubusercontent.com/3888696/143525034-90d35313-4c2f-48ed-8f1c-622c12ad69cc.png)
