### PR TITLE
fix: position label in front of billboard

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/Cluster.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Cluster.tsx
@@ -1,4 +1,4 @@
-import { Color, EntityCluster, HorizontalOrigin, VerticalOrigin } from "cesium";
+import { Color, Cartesian3, EntityCluster, HorizontalOrigin, VerticalOrigin } from "cesium";
 import React, { useEffect, useMemo } from "react";
 import { CustomDataSource } from "resium";
 
@@ -82,6 +82,7 @@ const Cluster: React.FC<Props> = ({
       clusterParam.label.fillColor = Color.fromCssColorString(
         clusterLabelTypography.color ?? "#FFF",
       );
+      clusterParam.label.eyeOffset = new Cartesian3(0, 0, -5);
       clusterParam.billboard.show = true;
       clusterParam.billboard.image = clusterImage;
       clusterParam.billboard.height = clusterImageWidth;


### PR DESCRIPTION
# Overview
Labels aren't displayed correctly, because labels and billboard are on the same level as billboards

## What I've done
Added a small `eyeOffset` to the label so it renders in front of the billboard
Solution according to [Label positioned behind billboard/point](https://groups.google.com/g/cesium-dev/c/cbypD-8kaSc)

## Screenshot
Old:
![Screenshot from 2021-12-17 23-16-07](https://user-images.githubusercontent.com/78056580/146608998-55868050-8192-44bc-ae76-948d61fc453f.png)

New:
![Screenshot from 2021-12-17 23-16-15](https://user-images.githubusercontent.com/78056580/146609052-0313267e-5e4c-4576-91cc-e4f39bdca647.png)

