### PR TITLE
fix: storytelling widget camera flight

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -13,7 +13,7 @@ import {
 } from "cesium";
 import type { Viewer as CesiumViewer, ImageryProvider, TerrainProvider } from "cesium";
 import CesiumDnD, { Context } from "cesium-dnd";
-import { isEqual, throttle } from "lodash-es";
+import { isEqual } from "lodash-es";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useDeepCompareEffect } from "react-use";
 import type { CesiumComponentRef, CesiumMovementEvent, RootEventTarget } from "resium";
@@ -165,14 +165,6 @@ export default ({
     initialCameraFlight.current = false;
   }, []);
 
-  const throttledCameraChange = useMemo(
-    () =>
-      throttle((c: Camera) => {
-        onCameraChange?.(c);
-      }, 100),
-    [onCameraChange],
-  );
-
   // call onCameraChange event after moving camera
   const emittedCamera = useRef<Camera>();
   const handleCameraMoveEnd = useCallback(() => {
@@ -182,9 +174,9 @@ export default ({
     const c = getCamera(viewer);
     if (c && !isEqual(c, camera)) {
       emittedCamera.current = c;
-      throttledCameraChange(c);
+      onCameraChange?.(c);
     }
-  }, [throttledCameraChange, camera, onCameraChange]);
+  }, [camera, onCameraChange]);
 
   // camera
   useEffect(() => {

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -113,7 +113,10 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
               ? property.cameraLimiter?.cameraLimitterTargetArea?.height ?? Number.POSITIVE_INFINITY
               : Number.POSITIVE_INFINITY
           }></ScreenSpaceCameraController>
-        <Camera onChange={handleCameraMoveEnd} percentageChanged={0.2} />
+        <Camera
+          onChange={handleCameraMoveEnd}
+          percentageChanged={property?.cameraLimiter?.cameraLimitterEnabled ? 0.2 : 0.5}
+        />
 
         {limiterDimensions && property?.cameraLimiter?.cameraLimitterShowHelper && (
           <Entity>


### PR DESCRIPTION
# Overview
- Storytelling is not reaching it's destination markers on published projects.

## What I've done
- Removed the `throttle` code, and got back the old value of `percentageChanged`.

## How I tested
Tested 3 things:
- storytelling 
- stutter camera
- camera limiter

