### PR TITLE
fix: the style of infobox block dropdown list is broken

### DIFF
--- a/src/components/atoms/ContentPicker/index.tsx
+++ b/src/components/atoms/ContentPicker/index.tsx
@@ -85,7 +85,6 @@ const ContentItem = styled.div`
 const ContentButton = styled.div`
   padding: 5px;
   width: 60px;
-  min-height: 60px;
   border: solid 0.5px transparent;
   box-sizing: border-box;
   text-align: center;

--- a/src/components/atoms/ContentPicker/index.tsx
+++ b/src/components/atoms/ContentPicker/index.tsx
@@ -52,7 +52,6 @@ const Wrapper = styled.div`
   box-sizing: border-box;
   border-radius: 3px;
   width: 288px;
-  height: 160px;
   color: ${props => props.theme.infoBox.mainText};
   box-shadow: 0 0 5px ${props => props.theme.infoBox.deepBg};
   &:after {
@@ -86,6 +85,7 @@ const ContentItem = styled.div`
 const ContentButton = styled.div`
   padding: 5px;
   width: 60px;
+  min-height: 60px;
   border: solid 0.5px transparent;
   box-sizing: border-box;
   text-align: center;

--- a/src/components/atoms/ContentPicker/index.tsx
+++ b/src/components/atoms/ContentPicker/index.tsx
@@ -73,6 +73,8 @@ const ContentsList = styled.div`
   display: flex;
   flex-wrap: wrap;
   height: 100%;
+  max-height: 200px;
+  overflow: auto;
 `;
 
 const ContentItem = styled.div`


### PR DESCRIPTION
# Overview

## What I've done
- Removed `height` property from the parent.

## Screenshot

![1](https://user-images.githubusercontent.com/78056580/150740982-8eba216d-762d-437d-a598-a9c877f36392.png)
![2](https://user-images.githubusercontent.com/78056580/150740989-319b6b25-a0ba-4027-9136-265b75e6e0e9.png)
![1](https://user-images.githubusercontent.com/78056580/150840820-db12f4cd-9c19-49b1-a14d-bae8f4f47d42.png)

