### PR TITLE
fix: plugin blocks cannot be deleted

### DIFF
--- a/src/components/molecules/EarthEditor/PropertyPane/PropertyItem/index.tsx
+++ b/src/components/molecules/EarthEditor/PropertyPane/PropertyItem/index.tsx
@@ -259,7 +259,7 @@ const PropertyItem: React.FC<Props> = ({
 
   const itemTitle = intl.formatMessage({ defaultMessage: "Basic" });
   const handleDelete = useCallback(() => {
-    if (!onRemovePane || !item?.title) return;
+    if (!onRemovePane) return;
     if (item?.title === itemTitle) {
       setModal(true);
     } else {


### PR DESCRIPTION
# Overview
Deleting custom blocks

## What I've done
- Removed name checking condition

## What I haven't done
- Did not add any features

## How I tested
- Create custom block
- Delete custom blocks
-  Delete infobox
- Delete builtin blocks

## Which point I want you to review particularly
- Code change

