### PR TITLE
feat: filter layers by viewport

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
@@ -77,20 +77,7 @@ export default function useEngineRef(
       getViewport: () => {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
-        const camera = getCamera(viewer);
-        const sceneCamera = new Cesium.Camera(viewer.scene);
-        if (camera) {
-          sceneCamera.setView({
-            destination: Cesium.Cartesian3.fromDegrees(camera.lng, camera.lat, camera.height),
-            orientation: {
-              heading: camera.heading,
-              pitch: camera.pitch,
-              roll: camera.roll,
-              up: sceneCamera.up,
-            },
-          });
-        }
-        return sceneCamera.computeViewRectangle();
+        return viewer.camera.computeViewRectangle();
       },
       zoomIn: amount => {
         const viewer = cesium.current?.cesiumElement;

--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
@@ -74,6 +74,24 @@ export default function useEngineRef(
           options,
         );
       },
+      getViewport: () => {
+        const viewer = cesium.current?.cesiumElement;
+        if (!viewer || viewer.isDestroyed()) return;
+        const camera = getCamera(viewer);
+        const sceneCamera = new Cesium.Camera(viewer.scene);
+        if (camera) {
+          sceneCamera.setView({
+            destination: Cesium.Cartesian3.fromDegrees(camera.lng, camera.lat, camera.height),
+            orientation: {
+              heading: camera.heading,
+              pitch: camera.pitch,
+              roll: camera.roll,
+              up: sceneCamera.up,
+            },
+          });
+        }
+        return sceneCamera.computeViewRectangle();
+      },
       zoomIn: amount => {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;

--- a/src/components/molecules/Visualizer/Engine/ref.ts
+++ b/src/components/molecules/Visualizer/Engine/ref.ts
@@ -1,3 +1,4 @@
+import Rectangle from "cesium/Source/Core/Rectangle";
 import { ComponentType, ReactNode } from "react";
 
 import { LatLngHeight, Camera, Typography } from "@reearth/util/value";
@@ -7,6 +8,7 @@ import type { Component } from "../Primitive";
 export type EngineRef = {
   name: string;
   requestRender: () => void;
+  getViewport: () => Rectangle | undefined;
   getCamera: () => Camera | undefined;
   getLocationFromScreenXY: (x: number, y: number) => LatLngHeight | undefined;
   flyTo: (destination: FlyToDestination, options?: CameraOptions) => void;

--- a/src/components/molecules/Visualizer/Plugin/api.ts
+++ b/src/components/molecules/Visualizer/Plugin/api.ts
@@ -107,6 +107,7 @@ export function exposed({
 export function commonReearth({
   engineName,
   events,
+  getLayersInViewport,
   layers,
   sceneProperty,
   tags,
@@ -126,6 +127,7 @@ export function commonReearth({
 }: {
   engineName: string;
   events: Events<ReearthEventType>;
+  getLayersInViewport: () => any;
   layers: () => LayerStore;
   sceneProperty: () => any;
   tags: () => Tag[];
@@ -144,6 +146,9 @@ export function commonReearth({
   zoomOut: GlobalThis["reearth"]["visualizer"]["camera"]["zoomOut"];
 }): CommonReearth {
   return {
+    get getLayersInViewport() {
+      return getLayersInViewport();
+    },
     version: window.REEARTH_CONFIG?.version || "",
     apiVersion: 1,
     visualizer: {

--- a/src/components/molecules/Visualizer/Plugin/api.ts
+++ b/src/components/molecules/Visualizer/Plugin/api.ts
@@ -127,7 +127,6 @@ export function commonReearth({
 }: {
   engineName: string;
   events: Events<ReearthEventType>;
-  getLayersInViewport: () => any;
   layers: () => LayerStore;
   sceneProperty: () => any;
   tags: () => Tag[];
@@ -137,6 +136,7 @@ export function commonReearth({
   layerOverriddenInfobox: () => GlobalThis["reearth"]["layers"]["overriddenInfobox"];
   layerOverriddenProperties: () => GlobalThis["reearth"]["layers"]["overriddenProperties"];
   selectLayer: GlobalThis["reearth"]["layers"]["select"];
+  getLayersInViewport: GlobalThis["reearth"]["layers"]["getLayersInViewport"];
   showLayer: GlobalThis["reearth"]["layers"]["show"];
   hideLayer: GlobalThis["reearth"]["layers"]["hide"];
   overrideLayerProperty: GlobalThis["reearth"]["layers"]["overrideProperty"];
@@ -146,9 +146,6 @@ export function commonReearth({
   zoomOut: GlobalThis["reearth"]["visualizer"]["camera"]["zoomOut"];
 }): CommonReearth {
   return {
-    get getLayersInViewport() {
-      return getLayersInViewport();
-    },
     version: window.REEARTH_CONFIG?.version || "",
     apiVersion: 1,
     visualizer: {
@@ -167,6 +164,9 @@ export function commonReearth({
       },
     },
     layers: {
+      get getLayersInViewport() {
+        return getLayersInViewport;
+      },
       get select() {
         return selectLayer;
       },

--- a/src/components/molecules/Visualizer/Plugin/context.tsx
+++ b/src/components/molecules/Visualizer/Plugin/context.tsx
@@ -51,6 +51,7 @@ export type Props = {
   lookAt: (dest: LookAtDestination) => void;
   zoomIn: (amount: number) => void;
   zoomOut: (amount: number) => void;
+  getLayersInViewport: () => void;
 };
 
 export type Context = {
@@ -82,6 +83,7 @@ export function Provider({
   hideLayer,
   selectLayer,
   overrideLayerProperty,
+  getLayersInViewport,
   flyTo,
   lookAt,
   zoomIn,
@@ -125,6 +127,7 @@ export function Provider({
         hideLayer,
         selectLayer,
         overrideLayerProperty,
+        getLayersInViewport,
         flyTo,
         lookAt,
         zoomIn,
@@ -148,6 +151,7 @@ export function Provider({
       hideLayer,
       selectLayer,
       overrideLayerProperty,
+      getLayersInViewport,
       flyTo,
       lookAt,
       zoomIn,

--- a/src/components/molecules/Visualizer/Plugin/types.ts
+++ b/src/components/molecules/Visualizer/Plugin/types.ts
@@ -11,7 +11,6 @@ export type GlobalThis = {
 export type Reearth = {
   readonly version: string;
   readonly apiVersion: number;
-  readonly getLayersInViewport: () => void;
   readonly visualizer: Visualizer;
   readonly ui: UI;
   readonly plugin: Plugin;
@@ -58,6 +57,7 @@ export type Layers = {
   readonly overriddenInfobox?: OverriddenInfobox;
   readonly overriddenProperties?: { [id: string]: any };
   /** Selects the layer with the specified ID; if the ID is undefined, the currently selected later will be deselected. */
+  readonly getLayersInViewport: () => void;
   readonly select: (id?: string, options?: SelectLayerOptions) => void;
   readonly show: (...id: string[]) => void;
   readonly hide: (...id: string[]) => void;

--- a/src/components/molecules/Visualizer/Plugin/types.ts
+++ b/src/components/molecules/Visualizer/Plugin/types.ts
@@ -11,6 +11,7 @@ export type GlobalThis = {
 export type Reearth = {
   readonly version: string;
   readonly apiVersion: number;
+  readonly getLayersInViewport: () => void;
   readonly visualizer: Visualizer;
   readonly ui: UI;
   readonly plugin: Plugin;

--- a/src/components/molecules/Visualizer/hooks.ts
+++ b/src/components/molecules/Visualizer/hooks.ts
@@ -1,3 +1,4 @@
+import { Rectangle, Cartographic } from "cesium";
 import { useRef, useEffect, useMemo, useState, useCallback, RefObject } from "react";
 import { initialize, pageview } from "react-ga";
 import { useSet } from "react-use";
@@ -334,7 +335,10 @@ function overridenInfoboxBlocks(
 }
 
 function useProviderProps(
-  props: Omit<ProviderProps, "engine" | "flyTo" | "lookAt" | "zoomIn" | "zoomOut" | "layers">,
+  props: Omit<
+    ProviderProps,
+    "engine" | "flyTo" | "lookAt" | "zoomIn" | "zoomOut" | "layers" | "getLayersInViewport"
+  >,
   engineRef: RefObject<EngineRef>,
   layers: LayerStore,
 ): ProviderProps {
@@ -373,6 +377,22 @@ function useProviderProps(
     [engineRef],
   );
 
+  const getLayersInViewport = useCallback(() => {
+    const rect = engineRef.current?.getViewport();
+    return layers.findAll(
+      layer =>
+        rect &&
+        layer.property &&
+        Rectangle.contains(
+          rect,
+          Cartographic.fromDegrees(
+            layer.property.default.location.lng,
+            layer.property.default.location.lat,
+          ),
+        ),
+    );
+  }, [engineRef, layers]);
+
   const zoomIn = useCallback(
     (amount: number) => {
       engineRef.current?.zoomIn(amount);
@@ -395,5 +415,6 @@ function useProviderProps(
     zoomIn,
     zoomOut,
     layers,
+    getLayersInViewport,
   };
 }

--- a/src/components/molecules/Visualizer/storybook.tsx
+++ b/src/components/molecules/Visualizer/storybook.tsx
@@ -77,6 +77,7 @@ export const context: ProviderProps = {
   zoomIn: act("zoomIn"),
   zoomOut: act("zoomOut"),
   overrideLayerProperty: act("overrideLayerProperty"),
+  getLayersInViewport: act("getLayersInViewport"),
 };
 
 function act<T extends any[], M extends (...args: T) => any>(


### PR DESCRIPTION
# Overview
Extend public API to include layers filtering by `viewport`

## What I've done
- Use `camera.computeViewRectangle()` to retrieve the viewport's rectangle.
- Loop through layers and use `Rectangle.contains` to check if layer is inside this rectangle or not. 

## How I tested
`reearth.layers.getLayersInViewport()` in console.