### PR TITLE
fix: button widget squishing its text & infobox mask click away

### DIFF
--- a/src/components/molecules/Visualizer/Infobox/Frame/index.tsx
+++ b/src/components/molecules/Visualizer/Infobox/Frame/index.tsx
@@ -37,6 +37,7 @@ export type Props = {
   useMask?: boolean;
   styles?: InfoboxStyles;
   showTitle?: boolean;
+  onMaskClick?: () => void;
   onClick?: () => void;
   onClickAway?: () => void;
   onEnter?: () => void;
@@ -62,6 +63,7 @@ const InfoBox: React.FC<Props> = ({
   styles,
   showTitle,
   children,
+  onMaskClick,
   onClick,
   onClickAway,
   onEnter,
@@ -107,7 +109,7 @@ const InfoBox: React.FC<Props> = ({
 
   return (
     <>
-      <Mask activate={open && useMask} />
+      <Mask activate={open && useMask} onClick={onMaskClick} />
       <StyledFloatedPanel
         className={className}
         visible={visible}
@@ -177,7 +179,7 @@ const Mask = styled.div<{ activate?: boolean }>`
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.6);
   overflow-x: hidden;
-  pointer-events: none;
+  // pointer-events: none;
 `;
 
 const StyledFloatedPanel = styled(FloatedPanel)<{

--- a/src/components/molecules/Visualizer/Infobox/index.tsx
+++ b/src/components/molecules/Visualizer/Infobox/index.tsx
@@ -31,6 +31,7 @@ export type Props = {
   visible?: boolean;
   pluginBaseUrl?: string;
   pluginProperty?: { [key: string]: any };
+  onMaskClick?: () => void;
   onBlockSelect?: (id?: string) => void;
   onBlockChange?: <T extends ValueType>(
     blockId: string,
@@ -58,6 +59,7 @@ const Infobox: React.FC<Props> = ({
   visible,
   pluginBaseUrl,
   pluginProperty,
+  onMaskClick,
   onBlockSelect,
   onBlockChange,
   onBlockMove,
@@ -93,6 +95,7 @@ const Infobox: React.FC<Props> = ({
       noContent={!blocks?.length}
       styles={property?.default}
       showTitle={property?.default?.showTitle}
+      onMaskClick={onMaskClick}
       onClick={() => selectedBlockId && onBlockSelect?.(undefined)}
       onEnter={() => setIsReadyToRender(false)}
       onEntered={() => setIsReadyToRender(true)}

--- a/src/components/molecules/Visualizer/Widget/Button/MenuButton.tsx
+++ b/src/components/molecules/Visualizer/Widget/Button/MenuButton.tsx
@@ -181,10 +181,10 @@ const Wrapper = styled.div<{ button?: Button; publishedTheme: PublishTheme }>`
 const Button = styled.div<{ button?: Button; publishedTheme: PublishTheme }>`
   display: flex;
   border-radius: ${metricsSizes["xs"]}px;
-  min-width: 32px;
-  height: 32px;
+  min-width: 35px;
+  height: 35px;
   padding: 0 10px;
-  line-height: 32px;
+  line-height: 35px;
   box-sizing: border-box;
   color: ${({ button, publishedTheme }) => button?.buttonColor || publishedTheme.mainText};
   cursor: pointer;
@@ -206,11 +206,10 @@ const MenuWrapper = styled.div`
 `;
 
 const MenuInnerWrapper = styled.div<{ button?: Button; publishedTheme: PublishTheme }>`
-  min-width: 32px;
+  min-width: 35px;
   width: 100%;
   color: ${({ button, publishedTheme }) => button?.buttonColor || publishedTheme.mainText};
-  overflow-wrap: break-word;
-  hyphens: auto;
+  white-space: nowrap;
 `;
 
 const MenuItem = styled(Flex)<{ item?: MenuItem; button?: Button; publishedTheme: PublishTheme }>`

--- a/src/components/molecules/Visualizer/Widget/Button/index.tsx
+++ b/src/components/molecules/Visualizer/Widget/Button/index.tsx
@@ -31,7 +31,6 @@ const Menu = ({ widget, sceneProperty }: Props): JSX.Element | null => {
 };
 
 const Wrapper = styled.div`
-  padding: 5px;
   display: flex;
 `;
 

--- a/src/components/molecules/Visualizer/WidgetAlignSystem/Zone.tsx
+++ b/src/components/molecules/Visualizer/WidgetAlignSystem/Zone.tsx
@@ -52,6 +52,7 @@ export default function Zone({
                 pluginBaseUrl={pluginBaseUrl}
                 isEditable={isEditable}
                 isBuilt={isBuilt}
+                wrapContent
               />
             ),
           )}

--- a/src/components/molecules/Visualizer/hooks.ts
+++ b/src/components/molecules/Visualizer/hooks.ts
@@ -161,6 +161,10 @@ export default ({
     engineRef.current?.requestRender();
   });
 
+  const onInfoboxMaskClick = useCallback(() => {
+    selectLayer(undefined);
+  }, [selectLayer]);
+
   return {
     engineRef,
     wrapperRef,
@@ -180,6 +184,7 @@ export default ({
     isLayerDragging,
     handleLayerDrag,
     handleLayerDrop,
+    onInfoboxMaskClick,
   };
 };
 

--- a/src/components/molecules/Visualizer/hooks.ts
+++ b/src/components/molecules/Visualizer/hooks.ts
@@ -161,10 +161,10 @@ export default ({
     engineRef.current?.requestRender();
   });
 
-  const onInfoboxMaskClick = useCallback(() => {
+  const handleInfoboxMaskClick = useCallback(() => {
     selectLayer(undefined);
   }, [selectLayer]);
-
+  
   return {
     engineRef,
     wrapperRef,

--- a/src/components/molecules/Visualizer/hooks.ts
+++ b/src/components/molecules/Visualizer/hooks.ts
@@ -184,7 +184,7 @@ export default ({
     isLayerDragging,
     handleLayerDrag,
     handleLayerDrop,
-    onInfoboxMaskClick,
+    handleInfoboxMaskClick,
   };
 };
 

--- a/src/components/molecules/Visualizer/index.tsx
+++ b/src/components/molecules/Visualizer/index.tsx
@@ -211,6 +211,7 @@ export default function Visualizer({
             onBlockSelect={selectBlock}
             renderInsertionPopUp={renderInfoboxInsertionPopUp}
             pluginBaseUrl={pluginBaseUrl}
+            onMaskClick={() => selectLayer(undefined)}
           />
         )}
         {children}

--- a/src/components/molecules/Visualizer/index.tsx
+++ b/src/components/molecules/Visualizer/index.tsx
@@ -212,7 +212,7 @@ export default function Visualizer({
             onBlockSelect={selectBlock}
             renderInsertionPopUp={renderInfoboxInsertionPopUp}
             pluginBaseUrl={pluginBaseUrl}
-            onMaskClick={onInfoboxMaskClick}
+            onMaskClick={handleInfoboxMaskClick}
           />
         )}
         {children}

--- a/src/components/molecules/Visualizer/index.tsx
+++ b/src/components/molecules/Visualizer/index.tsx
@@ -112,6 +112,7 @@ export default function Visualizer({
     handleLayerDrag,
     handleLayerDrop,
     isLayerDragging,
+    onInfoboxMaskClick,
   } = useHooks({
     engineType: props.engine,
     rootLayerId,
@@ -211,7 +212,7 @@ export default function Visualizer({
             onBlockSelect={selectBlock}
             renderInsertionPopUp={renderInfoboxInsertionPopUp}
             pluginBaseUrl={pluginBaseUrl}
-            onMaskClick={() => selectLayer(undefined)}
+            onMaskClick={onInfoboxMaskClick}
           />
         )}
         {children}

--- a/src/components/molecules/Visualizer/index.tsx
+++ b/src/components/molecules/Visualizer/index.tsx
@@ -112,7 +112,7 @@ export default function Visualizer({
     handleLayerDrag,
     handleLayerDrop,
     isLayerDragging,
-    onInfoboxMaskClick,
+    handleInfoboxMaskClick,
   } = useHooks({
     engineType: props.engine,
     rootLayerId,


### PR DESCRIPTION
# Overview
Had problem with the text inside button widgets gettings squished when width of viewer wasn't wide enough to safely contain multiple widgets side by side.

## What I've done
Updated the widget align system so that it will wrap its widgets if not enough space. This created a little issue with the Button widgets, so needed to update their min-sizes.
Also, as requested by @lavalse I have made it so the text inside the Button's dropdown menu won't wrap, which was especially undesirable with non-English scripts like Chinese characters.