### PR TITLE
fix: duplicate asset results

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "moduleNameMapper": {
             "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/test/__mocks__/fileMock.js",
             "\\.(css|less)$": "<rootDir>/src/test/__mocks__/styleMock.js",
-            "@reearth/(.+)": "<rootDir>/src/$1"
+            "@reearth/(.+)": "<rootDir>/src/$1",
+            "^lodash-es$": "lodash"
         },
         "transform": {
             "\\.ya?ml$": "jest-transform-yaml",

--- a/src/components/organisms/Common/AssetContainer/hooks.ts
+++ b/src/components/organisms/Common/AssetContainer/hooks.ts
@@ -164,11 +164,9 @@ export default (teamId?: string, allowDeletion?: boolean) => {
 
   useEffect(() => {
     return () => {
-      setTimeout(() => {
-        setSort(undefined);
-        setSearchTerm(undefined);
-        gqlCache.evict({ fieldName: "assets" });
-      }, 200);
+      setSort(undefined);
+      setSearchTerm(undefined);
+      gqlCache.evict({ fieldName: "assets" });
     };
   }, [gqlCache]);
 

--- a/src/gql/provider.tsx
+++ b/src/gql/provider.tsx
@@ -4,6 +4,7 @@ import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { SentryLink } from "apollo-link-sentry";
 import { createUploadLink } from "apollo-upload-client";
+import { isEqual } from "lodash-es";
 import React from "react";
 
 import { useAuth } from "@reearth/auth";
@@ -62,9 +63,11 @@ const Provider: React.FC = ({ children }) => {
             keyArgs: ["teamId", "keyword", "sort", "pagination", ["first", "last"]],
 
             merge(existing, incoming, { readField }) {
-              const merged = existing ? existing.edges.slice(0) : [];
-              let offset = offsetFromCursor(merged, existing?.pageInfo.endCursor, readField);
+              if (existing && incoming && isEqual(existing, incoming)) return incoming;
 
+              const merged = existing ? existing.edges.slice(0) : [];
+
+              let offset = offsetFromCursor(merged, existing?.pageInfo.endCursor, readField);
               if (offset < 0) offset = merged.length;
 
               for (let i = 0; i < incoming?.edges?.length; ++i) {


### PR DESCRIPTION
Fixes an issue where navigating to the asset's settings page would make it so the asset results would have duplicate items. 

There seems to be an issue with apollo for some users ([this issue ](https://github.com/vuejs/apollo/issues/185)or similar) where the merge callback would be called twice.

This solution uses lo-dash to check the equality of the existing cache and incoming query in the merge function, so that if they match, they won't be merged together.