### PR TITLE
fix: workspace name cannot be changed, error displayed when deleting assets

### DIFF
--- a/src/components/organisms/Common/AssetContainer/index.tsx
+++ b/src/components/organisms/Common/AssetContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useCallback } from "react";
 
 import MoleculeAssetContainer, {
   Asset as AssetType,
@@ -24,19 +24,19 @@ const AssetContainer: React.FC<Props> = ({
 }) => {
   const {
     assets,
+    initialAsset,
     isLoading,
     hasMoreAssets,
     sort,
     searchTerm,
+    selectedAssets,
+    selectAsset,
     getMoreAssets,
     createAssets,
     handleSortChange,
     handleSearchTerm,
     removeAssets,
-  } = useHooks(teamId, allowDeletion);
-
-  const initialAsset = assets?.find(a => a.url === initialAssetUrl);
-  const [selectedAssets, selectAsset] = useState<Asset[]>(initialAsset ? [initialAsset] : []);
+  } = useHooks(teamId, initialAssetUrl, allowDeletion);
 
   useEffect(() => {
     onURLShow?.(assets);
@@ -46,7 +46,7 @@ const AssetContainer: React.FC<Props> = ({
     if (initialAsset) {
       selectAsset([initialAsset]);
     }
-  }, [initialAsset]);
+  }, [selectAsset, initialAsset]);
 
   const filteredAssets = useMemo(() => {
     if (!assets) return;

--- a/src/components/organisms/Settings/Workspace/hooks.ts
+++ b/src/components/organisms/Settings/Workspace/hooks.ts
@@ -100,7 +100,7 @@ export default (params: Params) => {
     async (name?: string) => {
       if (!teamId || !name) return;
       const results = await updateTeamMutation({ variables: { teamId, name } });
-      if (results.errors || !results.data?.__typename) {
+      if (results.errors) {
         setNotification({
           type: "error",
           text: intl.formatMessage({ defaultMessage: "Failed to update workspace name." }),


### PR DESCRIPTION
Fixes bug where changing workspace name would show error notification and not update UI until refresh.

Fixes bug where deleting consecutive assets would throw an error even though deletion was successful.