### PR TITLE
Fix the redirect after exc button in any setting page

### DIFF
--- a/src/components/molecules/Settings/SettingPage/index.tsx
+++ b/src/components/molecules/Settings/SettingPage/index.tsx
@@ -1,5 +1,6 @@
-import { Link } from "@reach/router";
-import React, { useState } from "react";
+import { Link, navigate } from "@reach/router";
+import React, { useCallback, useState } from "react";
+import { useKeyPressEvent } from "react-use";
 
 import Icon from "@reearth/components/atoms/Icon";
 import Header, { Props } from "@reearth/components/molecules/Common/Header";
@@ -18,7 +19,10 @@ const SettingPage: React.FC<Props> = ({
   const handleClick = () => {
     setIsOpen(o => !o);
   };
-
+  const handleKeyDown = useCallback(() => {
+    navigate(`/dashboard/${currentTeam?.id}`);
+  }, []);
+  useKeyPressEvent("Escape", handleKeyDown);
   return (
     <Wrapper>
       <StyledHeader


### PR DESCRIPTION
# Overview
When user presses Esc in any setting page, System redirects him to the setting page of workspace   

## What I've done
Add handling for ESC keypress in setting pages 

## What I haven't done

## How I tested
by going to all setting page and press esc then system redirects me to dashboard.

## Screenshot

## Which point I want you to review particularly

## Memo
