### PR TITLE
fix: asset modal showing only image-based assets

### DIFF
--- a/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
@@ -8,7 +8,7 @@ export type LayoutTypes = "medium" | "small" | "list";
 
 export const fileFormats = ".kml,.czml,.topojson,.geojson,.json,.gltf,.glb";
 
-export const imageFormats = ".jpg,.jpeg,.png,.gif,.svg,.tiff";
+export const imageFormats = ".jpg,.jpeg,.png,.gif,.svg,.tiff,.webp";
 
 export type Asset = {
   id: string;

--- a/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
@@ -8,7 +8,7 @@ export type LayoutTypes = "medium" | "small" | "list";
 
 export const fileFormats = ".kml,.czml,.json,.gltf,.glb";
 
-export const imageFormats = ".jpg,.png,.gif,.svg,.tiff";
+export const imageFormats = ".jpg,.jpeg,.png,.gif,.svg,.tiff";
 
 export type Asset = {
   id: string;

--- a/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
@@ -6,7 +6,7 @@ export type SortType = "date" | "name" | "size";
 
 export type LayoutTypes = "medium" | "small" | "list";
 
-export const fileFormats = ".kml,.czml,.json,.gltf,.glb";
+export const fileFormats = ".kml,.czml,.topojson,.geojson,.json,.gltf,.glb";
 
 export const imageFormats = ".jpg,.jpeg,.png,.gif,.svg,.tiff";
 

--- a/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/hooks.ts
@@ -6,6 +6,10 @@ export type SortType = "date" | "name" | "size";
 
 export type LayoutTypes = "medium" | "small" | "list";
 
+export const fileFormats = ".kml,.czml,.json,.gltf,.glb";
+
+export const imageFormats = ".jpg,.png,.gif,.svg,.tiff";
+
 export type Asset = {
   id: string;
   teamId: string;
@@ -26,7 +30,6 @@ function handleScroll(
 
 export default ({
   isMultipleSelectable,
-  accept,
   selectedAssets,
   sort,
   smallCardOnly,
@@ -37,7 +40,6 @@ export default ({
   onSearch,
 }: {
   isMultipleSelectable?: boolean;
-  accept?: string;
   selectedAssets?: Asset[];
   sort?: { type?: SortType | null; reverse?: boolean };
   smallCardOnly?: boolean;
@@ -74,7 +76,7 @@ export default ({
       : "filterTime";
 
   const handleFileSelect = useFileInput(files => onCreateAssets?.(files), {
-    accept,
+    accept: imageFormats + "," + fileFormats,
     multiple: isMultipleSelectable,
   });
 

--- a/src/components/molecules/Common/AssetModal/AssetContainer/index.tsx
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/index.tsx
@@ -16,7 +16,7 @@ import AssetCard from "../AssetCard";
 import AssetListItem from "../AssetListItem";
 import AssetSelect from "../AssetSelect";
 
-import useHooks, { Asset as AssetType, LayoutTypes, SortType } from "./hooks";
+import useHooks, { Asset as AssetType, LayoutTypes, SortType, fileFormats } from "./hooks";
 
 export type Asset = AssetType;
 
@@ -32,8 +32,7 @@ export type Props = {
   selectedAssets?: Asset[];
   isLoading?: boolean;
   isMultipleSelectable?: boolean;
-  accept?: string;
-  fileType?: "image" | "video" | "file";
+  videoOnly?: boolean;
   height?: number;
   hasMoreAssets?: boolean;
   sort?: { type?: AssetSortType | null; reverse?: boolean };
@@ -52,10 +51,8 @@ export type Props = {
 const AssetContainer: React.FC<Props> = ({
   assets,
   isMultipleSelectable = false,
-  accept,
   initialAsset,
   selectedAssets,
-  fileType,
   height,
   hasMoreAssets,
   isLoading,
@@ -86,7 +83,6 @@ const AssetContainer: React.FC<Props> = ({
   } = useHooks({
     sort,
     isMultipleSelectable,
-    accept,
     selectedAssets,
     smallCardOnly,
     onSortChange,
@@ -101,11 +97,7 @@ const AssetContainer: React.FC<Props> = ({
       <Flex justify={onRemove ? "flex-end" : "center"}>
         <Button
           large
-          text={
-            fileType === "image"
-              ? intl.formatMessage({ defaultMessage: "Upload image" })
-              : intl.formatMessage({ defaultMessage: "Upload file" })
-          }
+          text={intl.formatMessage({ defaultMessage: "Upload file" })}
           icon="upload"
           type="button"
           buttonType={onRemove ? "secondary" : "primary"}
@@ -164,14 +156,9 @@ const AssetContainer: React.FC<Props> = ({
                 ? intl.formatMessage({
                     defaultMessage: "No assets match your search.",
                   })
-                : fileType === "image"
-                ? intl.formatMessage({
-                    defaultMessage:
-                      "You haven't uploaded any image assets yet. Click the upload button above and select an image from your computer.",
-                  })
                 : intl.formatMessage({
                     defaultMessage:
-                      "You haven't uploaded any file assets yet. Click the upload button above and select a compatible file from your computer.",
+                      "You haven't uploaded any assets yet. Click the upload button above and select a compatible file from your computer.",
                   })}
             </TemplateText>
           </Template>
@@ -194,6 +181,7 @@ const AssetContainer: React.FC<Props> = ({
                       key={a.id}
                       name={a.name}
                       cardSize={layoutType}
+                      icon={checkIfFileType(a.url, fileFormats) ? "file" : undefined}
                       url={a.url}
                       onCheck={() => onSelect?.(a)}
                       selected={selectedAssets?.includes(a)}
@@ -300,3 +288,21 @@ const TemplateText = styled(Text)`
 `;
 
 export default AssetContainer;
+
+function checkIfFileType(url: string, fileTypes: string) {
+  const formats = fileTypes.split(/,.|\./).splice(1);
+  let regexString = "\\.(";
+
+  for (let i = 0; i < formats.length; i++) {
+    if (i === formats.length - 1) {
+      regexString += formats[i];
+    } else {
+      regexString += formats[i] + "|";
+    }
+  }
+  regexString += ")$";
+
+  const regex = new RegExp(regexString);
+
+  return regex.test(url);
+}

--- a/src/components/molecules/Common/AssetModal/AssetContainer/index.tsx
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/index.tsx
@@ -16,7 +16,13 @@ import AssetCard from "../AssetCard";
 import AssetListItem from "../AssetListItem";
 import AssetSelect from "../AssetSelect";
 
-import useHooks, { Asset as AssetType, LayoutTypes, SortType, fileFormats } from "./hooks";
+import useHooks, {
+  Asset as AssetType,
+  LayoutTypes,
+  SortType,
+  fileFormats,
+  imageFormats,
+} from "./hooks";
 
 export type Asset = AssetType;
 
@@ -171,6 +177,7 @@ const AssetContainer: React.FC<Props> = ({
                     <AssetListItem
                       key={a.id}
                       asset={a}
+                      isImage={checkIfFileType(a.url, imageFormats)}
                       onCheck={() => onSelect?.(a)}
                       selected={selectedAssets?.includes(a)}
                       checked={initialAsset === a}

--- a/src/components/molecules/Common/AssetModal/AssetListItem/index.tsx
+++ b/src/components/molecules/Common/AssetModal/AssetListItem/index.tsx
@@ -21,21 +21,15 @@ export type Props = {
   selected?: boolean;
   checked?: boolean;
   onCheck?: (checked: boolean) => void;
+  isImage?: boolean;
 };
 
-const AssetListItem: React.FC<Props> = ({ asset, selected, checked, onCheck }) => {
+const AssetListItem: React.FC<Props> = ({ asset, selected, checked, onCheck, isImage }) => {
   const theme = useTheme();
   return (
     <ListItem key={asset.id} align="center" selected={selected} onClick={() => onCheck?.(!check)}>
       <Icon
-        icon={
-          checked
-            ? "checkCircle"
-            : asset.url &&
-              /\.(jpg|jpeg|png|gif|svg|webp|GIF|JPG|JPEG|PNG|SVG|WEBP)$/.test(asset.url)
-            ? "image"
-            : "file"
-        }
+        icon={checked ? "checkCircle" : isImage ? "image" : "file"}
         size={16}
         color={checked ? theme.assetCard.highlight : theme.assetCard.text}
       />

--- a/src/components/molecules/Common/AssetModal/index.tsx
+++ b/src/components/molecules/Common/AssetModal/index.tsx
@@ -24,7 +24,7 @@ export type Props = {
   className?: string;
   teamId?: string;
   initialAssetUrl?: string | null;
-  fileType?: "image" | "video";
+  videoOnly?: boolean;
   isOpen?: boolean;
   onSelect?: (value?: string) => void;
   toggleAssetModal?: (b: boolean) => void;
@@ -36,7 +36,7 @@ type Tabs = "assets" | "url";
 const AssetModal: React.FC<Props> = ({
   teamId,
   initialAssetUrl,
-  fileType,
+  videoOnly,
   isOpen,
   onSelect,
   toggleAssetModal,
@@ -56,11 +56,10 @@ const AssetModal: React.FC<Props> = ({
   const handleShowURL = useCallback(
     (assets?: AssetType[]) => {
       setShowURL(
-        fileType === "video" ||
-          !!(selectedAssetUrl && !assets?.some(e => e.url === selectedAssetUrl)),
+        videoOnly || !!(selectedAssetUrl && !assets?.some(e => e.url === selectedAssetUrl)),
       );
     },
-    [fileType, selectedAssetUrl],
+    [videoOnly, selectedAssetUrl],
   );
 
   const handleTextUrlChange = useCallback(text => {
@@ -68,11 +67,9 @@ const AssetModal: React.FC<Props> = ({
   }, []);
 
   const handleSave = useCallback(() => {
-    onSelect?.(
-      (selectedTab === "url" || fileType === "video" ? textUrl : selectedAssetUrl) || undefined,
-    );
+    onSelect?.((selectedTab === "url" || videoOnly ? textUrl : selectedAssetUrl) || undefined);
     toggleAssetModal?.(false);
-  }, [toggleAssetModal, selectedAssetUrl, selectedTab, onSelect, fileType, textUrl]);
+  }, [toggleAssetModal, selectedAssetUrl, selectedTab, onSelect, videoOnly, textUrl]);
 
   const resetValues = useCallback(() => {
     setTextUrl(showURL && initialAssetUrl ? initialAssetUrl : undefined);
@@ -90,7 +87,7 @@ const AssetModal: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialAssetUrl, showURL]);
 
-  return fileType === "video" ? (
+  return videoOnly ? (
     <Modal
       size="sm"
       title={intl.formatMessage({ defaultMessage: "Add video URL" })}
@@ -118,11 +115,7 @@ const AssetModal: React.FC<Props> = ({
     </Modal>
   ) : (
     <TabularModal<Tabs>
-      title={
-        fileType === "image"
-          ? intl.formatMessage({ defaultMessage: "Select Image" })
-          : intl.formatMessage({ defaultMessage: "Select Resource" })
-      }
+      title={intl.formatMessage({ defaultMessage: "Select Asset" })}
       isVisible={isOpen}
       size="lg"
       onClose={handleModalClose}
@@ -151,7 +144,6 @@ const AssetModal: React.FC<Props> = ({
           teamId={teamId}
           initialAssetUrl={initialAssetUrl}
           onAssetUrlSelect={selectAssetUrl}
-          fileType={fileType}
           smallCardOnly
           height={425}
           onURLShow={handleShowURL}
@@ -159,11 +151,7 @@ const AssetModal: React.FC<Props> = ({
       )}
       {selectedTab === "url" && (
         <TextContainer align="center">
-          <Title size="s">
-            {fileType === "image"
-              ? intl.formatMessage({ defaultMessage: "Image URL" })
-              : intl.formatMessage({ defaultMessage: "Resource URL" })}
-          </Title>
+          <Title size="s">{intl.formatMessage({ defaultMessage: "Resource URL" })}</Title>
           <StyledTextField value={textUrl} onChange={handleTextUrlChange} />
         </TextContainer>
       )}

--- a/src/components/molecules/EarthEditor/PropertyPane/PropertyField/URLField/index.tsx
+++ b/src/components/molecules/EarthEditor/PropertyPane/PropertyField/URLField/index.tsx
@@ -10,7 +10,7 @@ import { FieldProps } from "../types";
 
 export type AssetModalProps = Pick<
   AssetModalPropsType,
-  "isOpen" | "fileType" | "initialAssetUrl" | "onSelect" | "toggleAssetModal"
+  "isOpen" | "videoOnly" | "initialAssetUrl" | "onSelect" | "toggleAssetModal"
 >;
 
 export type Props = FieldProps<string> & {
@@ -69,7 +69,7 @@ const URLField: React.FC<Props> = ({
       {AssetModal && (
         <AssetModal
           isOpen={isAssetModalOpen}
-          fileType={fileType}
+          videoOnly={fileType == "video"}
           initialAssetUrl={value}
           onSelect={handleChange}
           toggleAssetModal={handleAssetModalOpen}

--- a/src/components/organisms/Common/AssetContainer/index.tsx
+++ b/src/components/organisms/Common/AssetContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useCallback } from "react";
+import React, { useEffect, useCallback } from "react";
 
 import MoleculeAssetContainer, {
   Asset as AssetType,
@@ -15,7 +15,7 @@ const AssetContainer: React.FC<Props> = ({
   teamId,
   initialAssetUrl,
   onAssetUrlSelect,
-  fileType,
+  videoOnly,
   smallCardOnly,
   allowDeletion,
   height,
@@ -48,24 +48,6 @@ const AssetContainer: React.FC<Props> = ({
     }
   }, [selectAsset, initialAsset]);
 
-  const filteredAssets = useMemo(() => {
-    if (!assets) return;
-    return assets.filter(
-      a =>
-        !fileType ||
-        a.url.match(fileType === "image" ? /\.(jpg|jpeg|png|gif|webp|svg)$/ : /\.(mp4|webm)$/),
-    );
-  }, [assets, fileType]);
-
-  const accept =
-    fileType === "image"
-      ? "image/*"
-      : fileType === "video"
-      ? "video/*"
-      : fileType
-      ? "*/*"
-      : undefined;
-
   const handleSelect = useCallback(
     (asset?: Asset) => {
       if (!asset) return;
@@ -83,13 +65,12 @@ const AssetContainer: React.FC<Props> = ({
 
   return (
     <MoleculeAssetContainer
-      assets={filteredAssets}
+      assets={assets}
       initialAsset={initialAsset}
       selectedAssets={selectedAssets}
       isLoading={isLoading}
       isMultipleSelectable={isMultipleSelectable}
-      accept={accept}
-      fileType={fileType}
+      videoOnly={videoOnly}
       height={height}
       hasMoreAssets={hasMoreAssets}
       sort={sort}

--- a/src/components/organisms/Common/AssetModal/index.tsx
+++ b/src/components/organisms/Common/AssetModal/index.tsx
@@ -14,13 +14,11 @@ const AssetModal: React.FC<Props> = ({
   isOpen,
   toggleAssetModal,
   onSelect,
-  fileType = "image",
 }) => {
   return (
     <MoleculeAssetModal
       teamId={teamId}
       initialAssetUrl={initialAssetUrl}
-      fileType={fileType}
       isOpen={isOpen}
       toggleAssetModal={toggleAssetModal}
       onSelect={onSelect}

--- a/src/components/organisms/Common/AssetModal/index.tsx
+++ b/src/components/organisms/Common/AssetModal/index.tsx
@@ -12,6 +12,7 @@ const AssetModal: React.FC<Props> = ({
   teamId,
   initialAssetUrl,
   isOpen,
+  videoOnly,
   toggleAssetModal,
   onSelect,
 }) => {
@@ -20,6 +21,7 @@ const AssetModal: React.FC<Props> = ({
       teamId={teamId}
       initialAssetUrl={initialAssetUrl}
       isOpen={isOpen}
+      videoOnly={videoOnly}
       toggleAssetModal={toggleAssetModal}
       onSelect={onSelect}
       assetContainer={AssetContainer}


### PR DESCRIPTION
closes reearth/reearth#260

## What I've done
- Fix issue where file assets weren't selectable for things like 3d model primitives
- (Re)Add file icon for files
- Redo file upload restrictions

Note: asset modal now doesn't support limiting shown assets based on whether it is an image or file (at the code level). 