### PR TITLE
fix: members section and new member button disappear after creating workspace from setting

### DIFF
--- a/src/gql/graphql-client-api.tsx
+++ b/src/gql/graphql-client-api.tsx
@@ -3152,7 +3152,7 @@ export type CreateTeamMutationVariables = Exact<{
 }>;
 
 
-export type CreateTeamMutation = { __typename?: 'Mutation', createTeam?: { __typename?: 'CreateTeamPayload', team: { __typename?: 'Team', id: string, name: string } } | null };
+export type CreateTeamMutation = { __typename?: 'Mutation', createTeam?: { __typename?: 'CreateTeamPayload', team: { __typename?: 'Team', id: string, name: string, personal: boolean, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }> } } | null };
 
 export type TeamFragment = { __typename?: 'Team', id: string, name: string, personal: boolean, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }> };
 
@@ -7922,6 +7922,16 @@ export const CreateTeamDocument = gql`
     team {
       id
       name
+      members {
+        user {
+          id
+          name
+          email
+        }
+        userId
+        role
+      }
+      personal
     }
   }
 }

--- a/src/gql/queries.ts
+++ b/src/gql/queries.ts
@@ -14,11 +14,20 @@ export const CREATE_TEAM = gql`
       team {
         id
         name
+        members {
+          user {
+            id
+            name
+            email
+          }
+          userId
+          role
+        }
+        personal
       }
     }
   }
 `;
-
 export const TEAMS = gql`
   fragment Team on Team {
     id


### PR DESCRIPTION
# Overview
When the user creates a new workspace from inside the setting page , the new workspace is created but the member section is empty and new member button disappears.

## What I've done
Change the graphql query and add the members to its result.

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
