### PR TITLE
ci: fix renovate bot not running at scheduled time

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,18 +15,17 @@
   "separateMajorMinor": false,
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "cesium"
       ],
       "groupName": "cesium",
-      "groupSlug": "cesium",
       "schedule": ["before 3am on the fourth day of the month"]
     },
     {
-      "packagePatterns": [
+      "matchPackagePatterns": [
         "*"
       ],
-      "excludePackagePatterns": [
+      "excludePackageNames": [
         "cesium"
       ],
       "groupName": "all dependencies",


### PR DESCRIPTION
closes https://github.com/reearth/reearth/issues/265
After updating the schedule for renovate bot, it didn't start on the new schedule. This should fix that