### PR TITLE
fix: downloaded file from plugin editor would only have partial code

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
         "graphiql": "^1.5.17",
         "graphql": "^16.3.0",
         "jotai": "^1.5.3",
+        "js-file-download": "^0.4.12",
         "leaflet": "^1.7.1",
         "lodash-es": "^4.17.20",
         "mini-svg-data-uri": "^1.4.3",

--- a/src/components/molecules/PluginEditor/hooks.ts
+++ b/src/components/molecules/PluginEditor/hooks.ts
@@ -1,3 +1,4 @@
+import fileDownload from "js-file-download";
 import { useState, useMemo, ChangeEvent, useEffect, useCallback } from "react";
 
 import type {
@@ -69,6 +70,11 @@ export default () => {
     },
   ];
 
+  const handleFileDownload = (body?: string, filename?: string) => {
+    if (!body) return;
+    fileDownload(body, filename ?? "untitled.js");
+  };
+
   const handleAlignSystemUpdate = (widget: Widget, newLoc: Position) => {
     setAlignSystem(() => {
       const alignment =
@@ -111,7 +117,7 @@ export default () => {
     setShowInfobox(!showInfobox);
   };
 
-  const openFile = async (e: ChangeEvent<HTMLInputElement>) => {
+  const handleFileOpen = async (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     const file = e.currentTarget.files?.[0];
     if (!file) return;
@@ -134,7 +140,7 @@ export default () => {
     };
   }, [sourceCode.body]);
 
-  const reset = useCallback(() => {
+  const handleFileReset = useCallback(() => {
     if (confirm("Are you sure you want to reset?")) {
       setSourceCode(hardSourceCode);
       handleAlignSystemUpdate(widget, defaultPosition);
@@ -155,13 +161,14 @@ export default () => {
     infoboxSize,
     showAlignSystem,
     showInfobox,
-    handleAlignSystemToggle,
-    handleInfoboxToggle,
-    openFile,
-    handleAlignSystemUpdate,
     setSourceCode,
     setMode,
     setInfoboxSize,
-    reset,
+    handleFileOpen,
+    handleFileDownload,
+    handleFileReset,
+    handleAlignSystemToggle,
+    handleAlignSystemUpdate,
+    handleInfoboxToggle,
   };
 };

--- a/src/components/molecules/PluginEditor/index.tsx
+++ b/src/components/molecules/PluginEditor/index.tsx
@@ -19,14 +19,15 @@ const PluginEditor: React.FC = () => {
     infoboxSize,
     showAlignSystem,
     showInfobox,
-    handleAlignSystemToggle,
-    handleInfoboxToggle,
-    openFile,
-    handleAlignSystemUpdate,
     setSourceCode,
     setMode,
     setInfoboxSize,
-    reset,
+    handleFileOpen,
+    handleFileDownload,
+    handleFileReset,
+    handleAlignSystemToggle,
+    handleAlignSystemUpdate,
+    handleInfoboxToggle,
   } = useHooks();
 
   return (
@@ -129,7 +130,7 @@ const PluginEditor: React.FC = () => {
             <div id="title" style={{ flex: 1 }}>
               <h3>Plugin editor navigation</h3>
               <p>Upload your plugin</p>
-              <input type="file" onChange={openFile}></input>
+              <input type="file" onChange={handleFileOpen}></input>
               <div
                 style={{
                   display: "flex",
@@ -137,12 +138,11 @@ const PluginEditor: React.FC = () => {
                   margin: "20px 0",
                 }}>
                 <SaveButton
-                  href={`data:application/javascript;charset=utf-8,${sourceCode.body}`}
-                  download={sourceCode.fileName}>
+                  onClick={() => handleFileDownload(sourceCode.body, sourceCode.fileName)}>
                   Save {sourceCode.fileName}
                 </SaveButton>
                 <Button
-                  onClick={reset}
+                  onClick={handleFileReset}
                   style={{ background: "orange", padding: "3px 6px", marginLeft: "20px" }}>
                   Reset
                 </Button>
@@ -287,15 +287,6 @@ const Button = styled.button<{ selected?: boolean }>`
   }
 `;
 
-const SaveButton = styled.a`
-  background: white;
-  border-radius: 3px;
-  padding: 4px 6px;
-  text-decoration: none;
-  color: black;
-  text-align: center;
-
-  :hover {
-    background: lightgrey;
-  }
+const SaveButton = styled(Button)`
+  padding: 6px 8px;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13337,6 +13337,11 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
+js-file-download@^0.4.12:
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
+  integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
+
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"


### PR DESCRIPTION
# Overview
When downloading your file in the plugin editor, the file would only copy some of the editor value. Not sure why this was happening, but the js-file-download dep works perfectly.
Also updated some names.