### PR TITLE
fix: Query names in refetchQueries not updated

### DIFF
--- a/src/components/organisms/Common/AssetContainer/hooks.ts
+++ b/src/components/organisms/Common/AssetContainer/hooks.ts
@@ -126,7 +126,7 @@ export default (teamId?: string, initialAssetUrl?: string | null, allowDeletion?
           assetIds.map(async assetId => {
             const result = await removeAssetMutation({
               variables: { assetId },
-              refetchQueries: ["Assets"],
+              refetchQueries: ["GetAssets"],
             });
             if (result.errors || result.data?.removeAsset) {
               setNotification({

--- a/src/components/organisms/Dashboard/hooks.ts
+++ b/src/components/organisms/Dashboard/hooks.ts
@@ -67,7 +67,7 @@ export default (teamId?: string) => {
     async (data: { name: string }) => {
       const results = await createTeamMutation({
         variables: { name: data.name },
-        refetchQueries: ["teams"],
+        refetchQueries: ["GetTeams"],
       });
       if (results.data?.createTeam) {
         setNotification({

--- a/src/components/organisms/EarthEditor/Header/hooks.ts
+++ b/src/components/organisms/EarthEditor/Header/hooks.ts
@@ -170,7 +170,7 @@ export default () => {
     async (data: { name: string }) => {
       const results = await createTeamMutation({
         variables: { name: data.name },
-        refetchQueries: ["teams"],
+        refetchQueries: ["GetTeams"],
       });
       if (results.data?.createTeam) {
         setTeam(results.data.createTeam.team);

--- a/src/components/organisms/EarthEditor/TagPane/commonHooks.ts
+++ b/src/components/organisms/EarthEditor/TagPane/commonHooks.ts
@@ -109,7 +109,7 @@ export default () => {
           sceneId,
           label,
         },
-        refetchQueries: ["getSceneTags"],
+        refetchQueries: ["GetSceneTags"],
       });
     },
     [createTagGroup, sceneId, sceneTagGroups, setNotification, tagErrorMessage.alreadyExist],
@@ -130,7 +130,7 @@ export default () => {
           label,
           parent: tagGroupId === DEFAULT_TAG_ID ? undefined : tagGroupId,
         },
-        refetchQueries: tagGroupId === DEFAULT_TAG_ID ? ["getSceneTags"] : [],
+        refetchQueries: tagGroupId === DEFAULT_TAG_ID ? ["GetSceneTags"] : [],
       });
       return tag;
     },
@@ -168,7 +168,7 @@ export default () => {
       if (selected?.type !== "layer") return;
       await detachTagFromLayer({
         variables: { tagId: tagItemId, layerId: selected.layerId },
-        refetchQueries: ["getLayerTags"],
+        refetchQueries: ["GetLayerTags"],
       });
     },
     [detachTagFromLayer, selected],
@@ -176,7 +176,7 @@ export default () => {
 
   const handleRemoveTagItemFromScene = useCallback(
     async (tagId: string) => {
-      await removeTag({ variables: { tagId }, refetchQueries: ["getSceneTags"] });
+      await removeTag({ variables: { tagId }, refetchQueries: ["GetSceneTags"] });
     },
     [removeTag],
   );
@@ -189,7 +189,7 @@ export default () => {
         setNotification({ type: "error", text: tagErrorMessage.tagGroupHasTags });
         return;
       }
-      await removeTag({ variables: { tagId: tagGroupId }, refetchQueries: ["getSceneTags"] });
+      await removeTag({ variables: { tagId: tagGroupId }, refetchQueries: ["GetSceneTags"] });
     },
     [removeTag, sceneTagGroups, setNotification, tagErrorMessage.tagGroupHasTags],
   );

--- a/src/components/organisms/Settings/Project/hooks.ts
+++ b/src/components/organisms/Settings/Project/hooks.ts
@@ -53,7 +53,7 @@ export default ({ projectId }: Params) => {
   const [updateProjectMutation] = useUpdateProjectMutation();
   const [archiveProjectMutation] = useArchiveProjectMutation();
   const [deleteProjectMutation] = useDeleteProjectMutation({
-    refetchQueries: ["Project"],
+    refetchQueries: ["GetProjects"],
   });
 
   const updateProjectName = useCallback(

--- a/src/components/organisms/Settings/ProjectList/hooks.ts
+++ b/src/components/organisms/Settings/ProjectList/hooks.ts
@@ -32,7 +32,7 @@ export default (teamId: string) => {
 
   const { data, loading, refetch } = useGetMeQuery();
   const [createNewProject] = useCreateProjectMutation({
-    refetchQueries: ["Project"],
+    refetchQueries: ["GetProjects"],
   });
   const [createScene] = useCreateSceneMutation();
 

--- a/src/components/organisms/Settings/SettingPage/hooks.ts
+++ b/src/components/organisms/Settings/SettingPage/hooks.ts
@@ -93,7 +93,7 @@ export default (params: Params) => {
     async (data: { name: string }) => {
       const results = await createTeamMutation({
         variables: { name: data.name },
-        refetchQueries: ["teams"],
+        refetchQueries: ["GetTeams"],
       });
       const team = results.data?.createTeam?.team;
       if (results) {

--- a/src/components/organisms/Settings/Workspace/hooks.ts
+++ b/src/components/organisms/Settings/Workspace/hooks.ts
@@ -74,7 +74,7 @@ export default (params: Params) => {
     async (data: { name: string }) => {
       const results = await createTeamMutation({
         variables: { name: data.name },
-        refetchQueries: ["teams"],
+        refetchQueries: ["GetTeams"],
       });
       const team = results.data?.createTeam?.team;
       if (results.errors || !results.data?.createTeam) {
@@ -117,7 +117,7 @@ export default (params: Params) => {
   );
 
   const [deleteTeamMutation] = useDeleteTeamMutation({
-    refetchQueries: ["teams"],
+    refetchQueries: ["GetTeams"],
   });
   const deleteTeam = useCallback(async () => {
     if (!teamId) return;
@@ -145,7 +145,7 @@ export default (params: Params) => {
           if (!teamId) return;
           const result = await addMemberToTeamMutation({
             variables: { userId, teamId, role: Role.Reader },
-            refetchQueries: ["teams"],
+            refetchQueries: ["GetTeams"],
           });
           const team = result.data?.addMemberToTeam?.team;
           if (result.errors || !team) {
@@ -202,7 +202,7 @@ export default (params: Params) => {
       if (!teamId) return;
       const result = await removeMemberFromTeamMutation({
         variables: { teamId, userId },
-        refetchQueries: ["teams"],
+        refetchQueries: ["GetTeams"],
       });
       const team = result.data?.removeMemberFromTeam?.team;
       if (result.errors || !team) {


### PR DESCRIPTION
# Overview

The query names used in refetchQuery are not updated, which will lead to some components can't get auto updated after some mutaions.

## What I've done

Updated the query names in refetchQuery of hooks:
- GetAssets
- GetTeams
- GetSceneTags
- GetLayerTags
- GetProjects

## How I tested

Create & remove projects / teams(workspace) / scene tags / layer tags, upload / remove assets of image.
