### PR TITLE
chore: add useT hook to i18n

### DIFF
--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -2,5 +2,4 @@ module.exports = {
   locales: ["en", "ja"],
   output: "src/i18n/translations/$LOCALE.yml",
   input: ["src/**/*.{ts,tsx}"],
-  useKeysAsDefaultValue: true,
 };

--- a/src/components/atoms/ConfirmationModal/index.tsx
+++ b/src/components/atoms/ConfirmationModal/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useTranslation } from "@reearth/i18n";
+import { useT } from "@reearth/i18n";
 
 import Button from "../Button";
 import Modal from "../Modal";
@@ -24,7 +24,7 @@ const ConfirmationModal: React.FC<Props> = ({
   isOpen,
   onClose,
 }) => {
-  const { t } = useTranslation();
+  const t = useT();
 
   const handleProceed = () => {
     onProceed();

--- a/src/components/molecules/Dashboard/Workspace.tsx
+++ b/src/components/molecules/Dashboard/Workspace.tsx
@@ -8,7 +8,7 @@ import Flex from "@reearth/components/atoms/Flex";
 import Icon from "@reearth/components/atoms/Icon";
 import Text from "@reearth/components/atoms/Text";
 import { Team as TeamType } from "@reearth/components/molecules/Dashboard/types";
-import { useTranslation } from "@reearth/i18n";
+import { useT } from "@reearth/i18n";
 import { styled, useTheme, metrics } from "@reearth/theme";
 import { metricsSizes } from "@reearth/theme/metrics";
 
@@ -20,7 +20,7 @@ export interface Props {
 }
 
 const Workspace: React.FC<Props> = ({ className, team }) => {
-  const { t } = useTranslation();
+  const t = useT();
   const theme = useTheme();
   const isSmallWindow = useMedia("(max-width: 1024px)");
 

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,3 +1,8 @@
+import { useTranslation } from "react-i18next";
+
 export { useTranslation } from "react-i18next";
 export { default as Provider } from "./provider";
 export { default as PublishedProvider } from "./publishedProvider";
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+export const useT = () => useTranslation().t;


### PR DESCRIPTION
- I added `useT` hook to `@reearth/i18n` that enables writing translations with less typing.
   - NOTE: Do not use other variable names than `t`, as translation will not be visible to the i18n-parser
- Disable i18n-parser option `useKeysAsDefaultValue` to clarify whether each text is translated or not. There is no effect on the on-screen display (if empty, the key is used as is).