### PR TITLE
fix: plugin API cameramove event is not emitted in published pages

### DIFF
--- a/src/components/molecules/Visualizer/hooks.ts
+++ b/src/components/molecules/Visualizer/hooks.ts
@@ -143,7 +143,7 @@ export default ({
       engineName: engineType || "",
       sceneProperty,
       tags,
-      camera,
+      camera: innerCamera,
       selectedLayer,
       layerSelectionReason,
       layerOverridenInfobox,


### PR DESCRIPTION
close https://github.com/reearth/reearth/issues/297