### PR TITLE
fix: vertical position style in infobox image block

### DIFF
--- a/src/components/molecules/Visualizer/Block/Image/index.tsx
+++ b/src/components/molecules/Visualizer/Block/Image/index.tsx
@@ -100,7 +100,7 @@ const Image = styled.img<{
   display: block;
   width: 100%;
   max-width: 100%;
-  height: auto;
+  height: 100%;
   max-height: ${props =>
     props.infoboxSize === "large"
       ? props.name


### PR DESCRIPTION
# Overview

I fixed reearth/reearth#202.

## What I've done

I fixed to use `height: 100%;` when vertical position property is specified center in infobox image block.

## What I haven't done

## How I tested

## Screenshot

|Before|After|
|-|-|
|![Screen Shot 2022-05-30 at 20 57 28](https://user-images.githubusercontent.com/34934510/170990175-125353f3-44ca-40cf-bbfb-7cff958ef42b.png)|![Screen Shot 2022-05-30 at 20 57 38](https://user-images.githubusercontent.com/34934510/170990198-2024fecd-ce0d-4428-bc28-f74af52266d9.png)|

## Which point I want you to review particularly

## Memo
