### PR TITLE
fix: labeling hidden by marker symbol

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
@@ -143,7 +143,7 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
         ? y * (labelPos.includes("top") ? -1 : 1)
         : 0,
     );
-  }, [style, imgw, pointSize, imgh, labelPos]);
+  }, [isStyleImage, imgw, pointSize, imgh, labelPos]);
 
   const e = useRef<CesiumComponentRef<CesiumEntity>>(null);
   useEffect(() => {

--- a/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
@@ -134,7 +134,7 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
     const padding = imageSize ? 15 : 40;
     const x =
       (img?.width && imageSize && (!style || style === "image")
-        ? img?.width * imageSize
+        ? img.width * imageSize
         : pointSize) /
         2 +
       padding;

--- a/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
@@ -114,8 +114,9 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
       : undefined;
   }, [extrude, location, height]);
 
-  const [icon, img] = useIcon({
-    image,
+  const isStyleImage = !style || style === "image";
+  const [icon, imgw, imgh] = useIcon({
+    image: isStyleImage ? image : undefined,
     imageSize,
     crop,
     shadow,
@@ -131,19 +132,9 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
   );
 
   const pixelOffset = useMemo(() => {
-    const padding = imageSize ? 15 : 40;
-    const x =
-      (img?.width && imageSize && (!style || style === "image")
-        ? img.width * imageSize
-        : pointSize) /
-        2 +
-      padding;
-    const y =
-      (img?.height && imageSize && (!style || style === "image")
-        ? img.height * imageSize
-        : pointSize) /
-        2 +
-      padding;
+    const padding = 15;
+    const x = (isStyleImage ? imgw : pointSize) / 2 + padding;
+    const y = (isStyleImage ? imgh : pointSize) / 2 + padding;
     return new Cartesian2(
       labelPos.includes("left") || labelPos.includes("right")
         ? x * (labelPos.includes("left") ? -1 : 1)
@@ -152,7 +143,7 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
         ? y * (labelPos.includes("top") ? -1 : 1)
         : 0,
     );
-  }, [img?.width, img?.height, style, imageSize, pointSize, labelPos]);
+  }, [style, imgw, pointSize, imgh, labelPos]);
 
   const e = useRef<CesiumComponentRef<CesiumEntity>>(null);
   useEffect(() => {

--- a/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx
@@ -131,9 +131,19 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
   );
 
   const pixelOffset = useMemo(() => {
-    const padding = 15;
-    const x = (img?.width && style == "image" ? img.width : pointSize) / 2 + padding;
-    const y = (img?.height && style == "image" ? img.height : pointSize) / 2 + padding;
+    const padding = imageSize ? 15 : 40;
+    const x =
+      (img?.width && imageSize && (!style || style === "image")
+        ? img?.width * imageSize
+        : pointSize) /
+        2 +
+      padding;
+    const y =
+      (img?.height && imageSize && (!style || style === "image")
+        ? img.height * imageSize
+        : pointSize) /
+        2 +
+      padding;
     return new Cartesian2(
       labelPos.includes("left") || labelPos.includes("right")
         ? x * (labelPos.includes("left") ? -1 : 1)
@@ -142,7 +152,7 @@ const Marker: React.FC<PrimitiveProps<Property>> = ({ layer }) => {
         ? y * (labelPos.includes("top") ? -1 : 1)
         : 0,
     );
-  }, [img?.width, img?.height, style, pointSize, labelPos]);
+  }, [img?.width, img?.height, style, imageSize, pointSize, labelPos]);
 
   const e = useRef<CesiumComponentRef<CesiumEntity>>(null);
   useEffect(() => {

--- a/src/components/molecules/Visualizer/Engine/Cesium/common.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/common.ts
@@ -31,7 +31,8 @@ const defaultImageSize = 50;
 export const drawIcon = (
   c: HTMLCanvasElement,
   image: HTMLImageElement | undefined,
-  imageSize: number | undefined,
+  w: number,
+  h: number,
   crop: "circle" | "rounded" | "none" = "none",
   shadow = false,
   shadowColor = "rgba(0, 0, 0, 0.7)",
@@ -44,14 +45,6 @@ export const drawIcon = (
 
   ctx.save();
 
-  const w =
-    typeof imageSize === "number"
-      ? Math.floor(image.width * imageSize)
-      : Math.min(defaultImageSize, image.width);
-  const h =
-    typeof imageSize === "number"
-      ? Math.floor(image.height * imageSize)
-      : Math.floor((w / image.width) * image.height);
   c.width = w + shadowBlur;
   c.height = h + shadowBlur;
   ctx.shadowBlur = shadowBlur;
@@ -103,25 +96,27 @@ export const useIcon = ({
   shadowBlur?: number;
   shadowOffsetX?: number;
   shadowOffsetY?: number;
-}): [string, HTMLImageElement | undefined] => {
+}): [string, number, number] => {
   const img = useImage(image);
+
+  const w = !img
+    ? 0
+    : typeof imageSize === "number"
+    ? Math.floor(img.width * imageSize)
+    : Math.min(defaultImageSize, img.width);
+  const h = !img
+    ? 0
+    : typeof imageSize === "number"
+    ? Math.floor(img.height * imageSize)
+    : Math.floor((w / img.width) * img.height);
+
   const draw = useCallback(
     can =>
-      drawIcon(
-        can,
-        img,
-        imageSize,
-        crop,
-        shadow,
-        shadowColor,
-        shadowBlur,
-        shadowOffsetX,
-        shadowOffsetY,
-      ),
-    [crop, imageSize, img, shadow, shadowBlur, shadowColor, shadowOffsetX, shadowOffsetY],
+      drawIcon(can, img, w, h, crop, shadow, shadowColor, shadowBlur, shadowOffsetX, shadowOffsetY),
+    [crop, h, img, shadow, shadowBlur, shadowColor, shadowOffsetX, shadowOffsetY, w],
   );
   const canvas = useCanvas(draw);
-  return [canvas, img];
+  return [canvas, w, h];
 };
 
 export const ho = (o: "left" | "center" | "right" | undefined): HorizontalOrigin | undefined =>


### PR DESCRIPTION
# Overview
In this PR I fixed the bug where the label is hidden behind the marker image
this fixes reearth/reearth#207 and reearth/reearth#184 reearth-web

## What I've done
I modified the `pixelOffset` hook inside `src/components/molecules/Visualizer/Engine/Cesium/Marker/index.tsx`
and updated the equations for x and y with taking imageSize(imageScale) in condsideration.

## How I tested
Manually using google chrome.

## Screenshot
![image](https://user-images.githubusercontent.com/35835415/171595568-48293208-2caa-458a-b2ef-4373224219e1.png)
