### PR TITLE
fix: slight shift when capture a new position

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -173,7 +173,7 @@ export default ({
 
   // call onCameraChange event after moving camera
   const emittedCamera = useRef<Camera>();
-  const handleCameraMoveEnd = useCallback(() => {
+  const updateCamera = useCallback(() => {
     const viewer = cesium?.current?.cesiumElement;
     if (!viewer || viewer.isDestroyed() || !onCameraChange) return;
 
@@ -183,6 +183,14 @@ export default ({
       onCameraChange?.(c);
     }
   }, [camera, onCameraChange]);
+
+  const handleCameraChange = useCallback(() => {
+    updateCamera();
+  }, [updateCamera]);
+
+  const handleCameraMoveEnd = useCallback(() => {
+    updateCamera();
+  }, [updateCamera]);
 
   // camera
   useEffect(() => {
@@ -306,6 +314,7 @@ export default ({
     handleMount,
     handleUnmount,
     handleClick,
+    handleCameraChange,
     handleCameraMoveEnd,
   };
 };

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -56,6 +56,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     handleMount,
     handleUnmount,
     handleClick,
+    handleCameraChange,
     handleCameraMoveEnd,
   } = useHooks({
     ref,
@@ -114,7 +115,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
               : Number.POSITIVE_INFINITY
           }></ScreenSpaceCameraController>
         <Camera
-          onChange={handleCameraMoveEnd}
+          onChange={handleCameraChange}
           percentageChanged={0.2}
           onMoveEnd={handleCameraMoveEnd}
         />

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -113,7 +113,11 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
               ? property.cameraLimiter?.cameraLimitterTargetArea?.height ?? Number.POSITIVE_INFINITY
               : Number.POSITIVE_INFINITY
           }></ScreenSpaceCameraController>
-        <Camera onChange={handleCameraMoveEnd} percentageChanged={0.2} />
+        <Camera
+          onChange={handleCameraMoveEnd}
+          percentageChanged={0.2}
+          onMoveEnd={handleCameraMoveEnd}
+        />
 
         {limiterDimensions && property?.cameraLimiter?.cameraLimitterShowHelper && (
           <Entity>


### PR DESCRIPTION
close https://github.com/reearth/reearth/issues/303

# Overview

Internal state `Camera` got updated when engine cesium `Camera` `onChange` triggered;
Cesium camera use `percentageChanged` to control when trigger a onChange event;
When user capturing a new position, the internal camera does not get the latest cesium camera postion which lead to the shift.

## What I've done

Simply added `onMoveEnd` event handler to `Camera` so that camera state always got updated when move end.
Rename and split event handler for `onChange` and `onMoveEnd` although they do the same thing right now but maybe they will have defferent things to handle in the future.

## How I tested

Do capture position from the earth editor.

## Screenshot

before capture:
![image](https://user-images.githubusercontent.com/21994748/173278711-b03cb07e-d46f-45a6-9a4b-7a31826c95e9.png)


after capture:
![image](https://user-images.githubusercontent.com/21994748/173278690-8be0d297-6081-4095-bc7b-7f78d47a535c.png)


