### PR TITLE
fix: router typo

### DIFF
--- a/src/components/molecules/Settings/Navigation/index.tsx
+++ b/src/components/molecules/Settings/Navigation/index.tsx
@@ -45,14 +45,14 @@ const Navigation: React.FC<Props> = ({ team, project }) => {
               name={team.name as string}>
               <NavigationItem
                 level={3}
-                to={`/settings/workspace/${team.id}/asset`}
+                to={`/settings/workspaces/${team.id}/asset`}
                 name={t("Assets")}
               />
             </NavigationItem>
           )}
         </NavigationItem>
         <Divider margin="0" />
-        <NavigationItem to={`/settings/workspace/${team?.id}/projects`} name={t("Project List")}>
+        <NavigationItem to={`/settings/workspaces/${team?.id}/projects`} name={t("Project List")}>
           {project && !project.isArchived && (
             <NavigationItem
               level={2}
@@ -60,17 +60,17 @@ const Navigation: React.FC<Props> = ({ team, project }) => {
               name={project.name as string}>
               <NavigationItem
                 level={3}
-                to={`/settings/project/${project.id}/public`}
+                to={`/settings/projects/${project.id}/public`}
                 name={t("Public")}
               />
               <NavigationItem
                 level={3}
-                to={`/settings/project/${project.id}/dataset`}
+                to={`/settings/projects/${project.id}/dataset`}
                 name={t("Dataset")}
               />
               <NavigationItem
                 level={3}
-                to={`/settings/project/${project.id}/plugins`}
+                to={`/settings/projects/${project.id}/plugins`}
                 name={t("Plugins")}
               />
             </NavigationItem>


### PR DESCRIPTION
# Overview

some route target path are missing updates after the router got updated.

## What I've done

fix path `workspace` -> `workspaces`
fix path `project` -> `projects`

## How I tested

Visting these page:

setting page for project 
- Public
- Dataset
- Plugins

settings page:
- ProjectList
- Assets

## Which point I want you to review particularly

One note from the router updates:
Some urls are changed in order to make them more semantic. If someone bookmark and visit the former urls for these pages will get a 404.

## Memo
