### PR TITLE
fix: dataset page showing errors on page refreshing 

### DIFF
--- a/src/components/organisms/Settings/Project/Dataset/hooks.ts
+++ b/src/components/organisms/Settings/Project/Dataset/hooks.ts
@@ -34,7 +34,7 @@ export default (projectId: string) => {
 
   const { data, fetchMore, loading, networkStatus } = useDatasetsListQuery({
     variables: { sceneId: sceneId ?? "", first: datasetPerPage },
-    skip: !projectId,
+    skip: !sceneId,
     notifyOnNetworkStatusChange: true,
   });
 


### PR DESCRIPTION
# Overview
On setting page/dataset, if refresh page, a warning appears

## What I've done
skip the undefined or empty scene id when fetching the dataset list

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
