### PR TITLE
fix: dependency @emotion/utils error

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
         "use-file-input": "^1.0.0"
     },
     "resolutions": {
-        "@emotion/utils": "^1.1.0"
+        "@emotion/utils": "^1.1.0",
+        "@emotion/sheet": "^1.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -213,5 +213,8 @@
         "ts-easing": "^0.2.0",
         "use-callback-ref": "^1.3.0",
         "use-file-input": "^1.0.0"
+    },
+    "resolutions": {
+        "@emotion/utils": "^1.1.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,12 +1545,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@emotion/utils@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
-  integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
-
-"@emotion/utils@^1.0.0", "@emotion/utils@^1.1.0":
+"@emotion/utils@0.11.3", "@emotion/utils@^1.0.0", "@emotion/utils@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
   integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,20 +1491,10 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@0.9.4":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
-  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
-
-"@emotion/sheet@^1.1.0":
+"@emotion/sheet@0.9.4", "@emotion/sheet@^1.1.0", "@emotion/sheet@^1.1.1":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
-
-"@emotion/sheet@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.1.tgz#015756e2a9a3c7c5f11d8ec22966a8dbfbfac787"
-  integrity sha512-J3YPccVRMiTZxYAY0IOq3kd+hUP8idY8Kz6B/Cyo+JuXq52Ek+zbPbSQUrVQp95aJ+lsAW7DPL1P2Z+U1jGkKA==
 
 "@emotion/styled-base@^10.3.0":
   version "10.3.0"


### PR DESCRIPTION
# Overview

When deploy preview on netlify it come up with warning:

`WARNING in ./node_modules/react-spinners/node_modules/@emotion/react/dist/emotion-element-cbed451f.browser.esm.js 183:2-16
export 'registerStyles' (imported as 'registerStyles') was not found in '@emotion/utils' (possible exports: getRegisteredStyles, insertStyles)`

And the preview page throw error:

`vendor-c0b5c364.108108bf.js:2 TypeError: (0 , r.registerStyles) is not a function`

This makes the preview not working.

More discussions can be found [here](https://github.com/emotion-js/emotion/issues/2702).

## What I've done

Add "resolutions" for @emotion/utils to force using v1.1.0
