### PR TITLE
fix: Cesium flashes on camera change

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/PhotoOverlay/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/PhotoOverlay/hooks.ts
@@ -79,8 +79,8 @@ export default function ({ isSelected, camera }: { isSelected?: boolean; camera?
       const fov = prevCamera.current?.fov ?? defaultFOV;
       flyTo?.({ fov }, { duration: 0 });
     }
-    // skip camera flight when selected layer was changed by storytelling widget
-    startTransition(!isSelected, storytelling.current ? !isSelected : !cameraRef.current);
+    // skip camera flight when is not selected
+    startTransition(!isSelected, !isSelected);
   }, [flyTo, startTransition, isSelected]);
 
   const transition = useTransition(

--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -172,14 +172,12 @@ export default ({
   }, []);
 
   // call onCameraChange event after moving camera
-  const emittedCamera = useRef<Camera>();
   const updateCamera = useCallback(() => {
     const viewer = cesium?.current?.cesiumElement;
     if (!viewer || viewer.isDestroyed() || !onCameraChange) return;
 
     const c = getCamera(viewer);
     if (c && !isEqual(c, camera)) {
-      emittedCamera.current = c;
       onCameraChange?.(c);
     }
   }, [camera, onCameraChange]);
@@ -191,14 +189,6 @@ export default ({
   const handleCameraMoveEnd = useCallback(() => {
     updateCamera();
   }, [updateCamera]);
-
-  // camera
-  useEffect(() => {
-    if (camera && (!emittedCamera.current || emittedCamera.current !== camera)) {
-      engineAPI.flyTo(camera, { duration: 0 });
-      emittedCamera.current = undefined;
-    }
-  }, [camera, engineAPI]);
 
   // manage layer selection
   useEffect(() => {


### PR DESCRIPTION
# Overview

The earth flashes when zoom in/out or rotate fast.

I found the direct reason for this is from the hooks inside engine/cesium which is in order to fix camera fly bug with photooverlay. It will campare the `emittedCamera.current` with `camera` and if they're not equal then make a `flyto`.
These one should be equal in most situation but i found it not equal at most time now (maybe related to react v18 state update logic i'm not sure).

This is a quick fix, plz let me know if i misunderstood anything.

## What I've done

- remove the hook useEffect inside engine/cesium which is in order to fix camera fly bug with photooverlay so the flash will not happen
- fix photooverlay camera fly issue by always skip for unselected photooverlay item

## How I tested

- zoom in/out and rotate the earth fast to check the flash
- add markers and photooverlays
- set camera pos and photo for photooverlays
- select markers/photooverlays from left pane(layers) to check the animations
- add markers/photooverlays into storytelling and check the animations
- use storytelling in published page to check the animations
