### PR TITLE
fix: layers pane does not update after move layer or create folder 

### DIFF
--- a/src/components/organisms/EarthEditor/OutlinePane/hooks.tsx
+++ b/src/components/organisms/EarthEditor/OutlinePane/hooks.tsx
@@ -209,6 +209,7 @@ export default () => {
           destLayerId,
           index: i,
         },
+        refetchQueries: ["GetLayers"],
       });
     },
     [moveLayerMutation],
@@ -295,6 +296,7 @@ export default () => {
         index: layerIndex?.[layerIndex.length - 1],
         name: t("Folder"),
       },
+      refetchQueries: ["GetLayers"],
     });
   }, [rootLayerId, data?.layer, selected, addLayerGroupMutation, t]);
 


### PR DESCRIPTION
# Overview

Bug: when click on the 'create new folder' or move layer on the Outline pane -> layers, the layers list did not got update which will mislead the users.

## What I've done

Add refetch to `moveLayerMutation` and `addLayerGroupMutation`

## How I tested

- create new folder (add layer group)
- drag layer in/out of the folder

## Screenshot

![image](https://user-images.githubusercontent.com/21994748/176446542-b5372da7-b3de-486b-9edb-cd843c03e644.png)

## Which point I want you to review particularly

It seems to be an obvious bug and i'm not sure when it starts to happen.
