### PR TITLE
fix: layer drag and drop does not work with indicators

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
@@ -27,6 +27,18 @@ export default function Indicator({ className, property }: Props): JSX.Element |
   const [img, w, h] = useIcon({ image: indicator_image, imageSize: indicator_image_scale });
 
   useEffect(() => {
+    !(
+      property?.indicator?.indicator_type === "default" ||
+      property?.indicator?.indicator_type === undefined
+    )
+      ? viewer?.selectionIndicator.viewModel.selectionIndicatorElement.setAttribute(
+          "hidden",
+          "true",
+        )
+      : viewer?.selectionIndicator.viewModel.selectionIndicatorElement.removeAttribute("hidden");
+  }, [property?.indicator?.indicator_type, viewer, viewer?.selectionIndicator]);
+
+  useEffect(() => {
     if (!viewer) return;
     const handleTick = () => {
       if (viewer.isDestroyed()) return;

--- a/src/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
@@ -28,8 +28,7 @@ export default function Indicator({ className, property }: Props): JSX.Element |
 
   useEffect(() => {
     !(
-      property?.indicator?.indicator_type === "default" ||
-      property?.indicator?.indicator_type === undefined
+      !indicator_type || indicator_type === "default"
     )
       ? viewer?.selectionIndicator.viewModel.selectionIndicatorElement.setAttribute(
           "hidden",

--- a/src/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/core/Indicator.tsx
@@ -27,15 +27,13 @@ export default function Indicator({ className, property }: Props): JSX.Element |
   const [img, w, h] = useIcon({ image: indicator_image, imageSize: indicator_image_scale });
 
   useEffect(() => {
-    !(
-      !indicator_type || indicator_type === "default"
-    )
+    !(!indicator_type || indicator_type === "default")
       ? viewer?.selectionIndicator.viewModel.selectionIndicatorElement.setAttribute(
           "hidden",
           "true",
         )
       : viewer?.selectionIndicator.viewModel.selectionIndicatorElement.removeAttribute("hidden");
-  }, [property?.indicator?.indicator_type, viewer, viewer?.selectionIndicator]);
+  }, [indicator_type, viewer, viewer?.selectionIndicator]);
 
   useEffect(() => {
     if (!viewer) return;

--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -60,16 +60,6 @@ export default ({
   // imagery layers
   const [imageryLayers, setImageryLayers] = useState<ImageryLayerData[]>();
 
-  // indicator
-  const selectionIndicator = useMemo(
-    () =>
-      !!(
-        property?.indicator?.indicator_type == undefined ||
-        property?.indicator?.indicator_type == "default"
-      ),
-    [property?.indicator?.indicator_type],
-  );
-
   useDeepCompareEffect(() => {
     const newTiles = (property?.tiles?.length ? property.tiles : undefined)
       ?.map(
@@ -311,7 +301,6 @@ export default ({
     limiterDimensions,
     cameraViewOuterBoundaries,
     cameraViewBoundariesMaterial,
-    selectionIndicator,
     handleMount,
     handleUnmount,
     handleClick,

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -54,7 +54,6 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     limiterDimensions,
     cameraViewOuterBoundaries,
     cameraViewBoundariesMaterial,
-    selectionIndicator,
     handleMount,
     handleUnmount,
     handleClick,
@@ -88,7 +87,6 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         navigationHelpButton={false}
         projectionPicker={false}
         sceneModePicker={false}
-        selectionIndicator={selectionIndicator}
         creditContainer={creditContainer}
         style={{
           width: small ? "300px" : "auto",


### PR DESCRIPTION
# Overview
Fix the Dnd in selection indicator in cesium viewer.
 
## What I've done
Instead of disabling the selection indicator in the viewer constructor , I modified the element style itself , and by this way no need to reconstruct the viewer each time we change the indicator and also the Dnd should work fine. 

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
