### PR TITLE
fix: unselect layer not work properly

### DIFF
--- a/src/components/molecules/Visualizer/hooks.ts
+++ b/src/components/molecules/Visualizer/hooks.ts
@@ -264,9 +264,8 @@ function useLayers({
 
   const selectLayer = useCallback(
     (id?: string, { reason, overriddenInfobox }: SelectLayerOptions = {}) => {
-      if (!id || !layers.findById(id)) return;
       innerSelectLayer(id);
-      onSelect?.(id);
+      onSelect?.(id && !!layers.findById(id) ? id : undefined);
       setSelectionReason(reason);
       setPrimitiveOverridenInfobox(overriddenInfobox);
     },


### PR DESCRIPTION
# Overview

When click on blank space of map it should unselect layers but it doesn't work due to a bug.

The bug comes from updateing selectLayer functions of organisms `CanvasArea` and molecusles `Visualizer`. In the past the `CanvasArea` select funtion will check if the layer can be got by `layers.findById` and after update this condition should be moved into `Visualizer` selectLayer function. When reviewing, the code looks like can be refactored and i did it without thinking clearly. My mistake.  

## What I've done

Update the `selectLayer` function.

## What I haven't done

## How I tested

Select layer and click on blank space to unselect it.

## Screenshot

## Which point I want you to review particularly

## Memo
