### PR TITLE
refactor: refactor the infinite scroll wrapper and queries

### DIFF
--- a/src/components/atoms/InfiniteScroll/hooks.ts
+++ b/src/components/atoms/InfiniteScroll/hooks.ts
@@ -1,0 +1,23 @@
+import { MutableRefObject } from "react";
+
+export default (onLoadMore?: () => void) => {
+  const handleAutoFillPage = (ref: MutableRefObject<HTMLDivElement | undefined | null>) => {
+    if (ref.current && ref.current?.scrollHeight <= document.documentElement.clientHeight) {
+      onLoadMore?.();
+    }
+  };
+
+  const handleScrollToBottom = (
+    { currentTarget }: React.UIEvent<HTMLDivElement, UIEvent>,
+    threshold = 5,
+  ) => {
+    if (
+      currentTarget.scrollTop + currentTarget.clientHeight >=
+      currentTarget.scrollHeight - threshold
+    ) {
+      onLoadMore?.();
+    }
+  };
+
+  return { handleAutoFillPage, handleScrollToBottom };
+};

--- a/src/components/atoms/InfiniteScroll/index.tsx
+++ b/src/components/atoms/InfiniteScroll/index.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode, useEffect, useRef } from "react";
+
+import { styled } from "@reearth/theme";
+
+import useHooks from "./hooks";
+
+type Props = {
+  className?: string;
+  loading?: boolean;
+  hasMoreItems?: boolean;
+  children?: ReactNode;
+  onGetMoreItems?: () => void;
+};
+
+const InfiniteScrollWrapper: React.FC<Props> = ({
+  className,
+  loading,
+  hasMoreItems,
+  onGetMoreItems,
+  children,
+}) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const { handleAutoFillPage, handleScrollToBottom } = useHooks(onGetMoreItems);
+
+  useEffect(() => {
+    if (wrapperRef.current && !loading && hasMoreItems) handleAutoFillPage(wrapperRef);
+  }, [handleAutoFillPage, hasMoreItems, loading, onGetMoreItems]);
+
+  return (
+    <Wrapper
+      ref={wrapperRef}
+      className={className}
+      onScroll={e => !loading && hasMoreItems && handleScrollToBottom(e)}>
+      {children}
+    </Wrapper>
+  );
+};
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+`;
+export default React.memo(InfiniteScrollWrapper);

--- a/src/components/molecules/Common/AssetModal/AssetContainer/index.tsx
+++ b/src/components/molecules/Common/AssetModal/AssetContainer/index.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef } from "react";
-
 import Button from "@reearth/components/atoms/Button";
 import Divider from "@reearth/components/atoms/Divider";
 import Flex from "@reearth/components/atoms/Flex";
 import Icon from "@reearth/components/atoms/Icon";
+import InfiniteScrollWrapper from "@reearth/components/atoms/InfiniteScroll";
 import Loading from "@reearth/components/atoms/Loading";
 import SearchBar from "@reearth/components/atoms/SearchBar";
 import Text from "@reearth/components/atoms/Text";
@@ -11,7 +10,6 @@ import AssetDeleteModal from "@reearth/components/molecules/Common/AssetModal/As
 import { useT } from "@reearth/i18n";
 import { styled } from "@reearth/theme";
 import { metricsSizes } from "@reearth/theme/metrics";
-import { autoFillPage, onScrollToBottom } from "@reearth/util/infinite-scroll";
 
 import AssetCard from "../AssetCard";
 import AssetListItem from "../AssetListItem";
@@ -100,11 +98,6 @@ const AssetContainer: React.FC<Props> = ({
     onRemove,
     onSearch,
   });
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (wrapperRef.current && !isLoading && hasMoreAssets) autoFillPage(wrapperRef, onGetMore);
-  }, [hasMoreAssets, isLoading, onGetMore]);
 
   return (
     <Wrapper>
@@ -175,8 +168,9 @@ const AssetContainer: React.FC<Props> = ({
           </Template>
         ) : (
           <AssetListWrapper
-            ref={wrapperRef}
-            onScroll={e => !isLoading && hasMoreAssets && onScrollToBottom(e, onGetMore)}>
+            loading={isLoading}
+            hasMoreItems={hasMoreAssets}
+            onGetMoreItems={onGetMore}>
             <AssetList layoutType={layoutType}>
               {layoutType === "list"
                 ? assets?.map(a => (
@@ -244,10 +238,9 @@ const AssetWrapper = styled.div<{ height?: number }>`
   justify-content: space-between;
 `;
 
-const AssetListWrapper = styled.div`
+const AssetListWrapper = styled(InfiniteScrollWrapper)`
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
   scrollbar-width: none;
   &::-webkit-scrollbar {
     display: none;

--- a/src/components/molecules/Dashboard/index.tsx
+++ b/src/components/molecules/Dashboard/index.tsx
@@ -1,8 +1,8 @@
-import { ReactNode, useEffect, useRef } from "react";
+import { ReactNode } from "react";
 
+import InfiniteScrollWrapper from "@reearth/components/atoms/InfiniteScroll";
 import Loading from "@reearth/components/atoms/Loading";
 import { styled } from "@reearth/theme";
-import { autoFillPage, onScrollToBottom } from "@reearth/util/infinite-scroll";
 
 export * from "./types";
 
@@ -23,20 +23,12 @@ const Dashboard: React.FC<Props> = ({
   hasMoreProjects,
   onGetMoreProjects,
 }) => {
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (wrapperRef.current && !isLoading && hasMoreProjects)
-      autoFillPage(wrapperRef, onGetMoreProjects);
-  }, [hasMoreProjects, isLoading, onGetMoreProjects]);
-
   return (
     <Wrapper
       className={className}
-      ref={wrapperRef}
-      onScroll={e => {
-        !isLoading && hasMoreProjects && onScrollToBottom(e, onGetMoreProjects);
-      }}>
+      loading={isLoading}
+      hasMoreItems={hasMoreProjects}
+      onGetMoreItems={onGetMoreProjects}>
       {header}
       <Content>
         {children}
@@ -46,10 +38,8 @@ const Dashboard: React.FC<Props> = ({
   );
 };
 
-const Wrapper = styled.div`
+const Wrapper = styled(InfiniteScrollWrapper)`
   background: ${({ theme }) => theme.dashboard.bg};
-  height: 100%;
-  overflow: auto;
 `;
 
 const Content = styled.div`

--- a/src/components/molecules/Settings/Project/Dataset/DatasetList/index.tsx
+++ b/src/components/molecules/Settings/Project/Dataset/DatasetList/index.tsx
@@ -9,7 +9,7 @@ export type Item = {
 };
 
 export type Props = {
-  items: Item[];
+  items?: Item[];
   isLoading?: boolean;
   hasMore?: boolean;
   removeDatasetSchema?: (schemaId: string) => void;
@@ -19,7 +19,7 @@ export type Props = {
 const DatasetList: React.FC<Props> = ({ items, removeDatasetSchema }) => {
   return (
     <Wrapper>
-      {items.map(item => (
+      {items?.map(item => (
         <DatasetItem key={item.id} {...item} removeDatasetSchema={removeDatasetSchema} />
       ))}
     </Wrapper>

--- a/src/components/molecules/Settings/Project/Dataset/DatasetSection/index.tsx
+++ b/src/components/molecules/Settings/Project/Dataset/DatasetSection/index.tsx
@@ -10,7 +10,7 @@ import { useT } from "@reearth/i18n";
 import { styled } from "@reearth/theme";
 
 type Props = {
-  datasetSchemas: Item[];
+  datasetSchemas?: Item[];
   removeDatasetSchema: (schemaId: string) => void;
   onDatasetImport?: (file: File, datasetSchemaId: string | null) => void | Promise<void>;
 };

--- a/src/components/molecules/Settings/SettingPage/index.tsx
+++ b/src/components/molecules/Settings/SettingPage/index.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 
 import Icon from "@reearth/components/atoms/Icon";
+import InfiniteScrollWrapper from "@reearth/components/atoms/InfiniteScroll";
 import Loading from "@reearth/components/atoms/Loading";
 import Header, { Props } from "@reearth/components/molecules/Common/Header";
 import ProjectMenu from "@reearth/components/molecules/Common/ProjectMenu";
 import Navigation from "@reearth/components/molecules/Settings/Navigation";
 import { styled } from "@reearth/theme";
-import { autoFillPage, onScrollToBottom } from "@reearth/util/infinite-scroll";
 
 export type SettingPageProps = {
   loading?: boolean;
@@ -30,12 +30,6 @@ const SettingPage: React.FC<SettingPageProps> = ({
     setIsOpen(o => !o);
   };
 
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (wrapperRef.current && !loading && hasMoreItems) autoFillPage(wrapperRef, onScroll);
-  }, [hasMoreItems, loading, onScroll]);
-
   return (
     <Wrapper>
       <StyledHeader
@@ -52,11 +46,7 @@ const SettingPage: React.FC<SettingPageProps> = ({
           currentProject && <ProjectMenu currentProject={currentProject} teamId={currentTeam?.id} />
         }
       />
-      <BodyWrapper
-        ref={wrapperRef}
-        onScroll={e => {
-          !loading && hasMoreItems && onScrollToBottom(e, onScroll);
-        }}>
+      <BodyWrapper loading={loading} hasMoreItems={hasMoreItems} onGetMoreItems={onScroll}>
         <LeftWrapper>
           <Navigation team={currentTeam} project={currentProject} />
         </LeftWrapper>
@@ -96,10 +86,8 @@ const Wrapper = styled.div`
   flex-direction: column;
 `;
 
-const BodyWrapper = styled.div`
-  height: 100%;
+const BodyWrapper = styled(InfiniteScrollWrapper)`
   padding-top: 48px;
-  overflow-y: scroll;
 `;
 
 const LeftWrapper = styled.div`

--- a/src/components/organisms/Common/AssetContainer/hooks.ts
+++ b/src/components/organisms/Common/AssetContainer/hooks.ts
@@ -2,7 +2,6 @@ import { useApolloClient } from "@apollo/client";
 import { useCallback, useState, useEffect } from "react";
 
 import {
-  GetAssetsQuery,
   useCreateAssetMutation,
   useRemoveAssetMutation,
   useGetAssetsQuery,
@@ -11,8 +10,6 @@ import {
 } from "@reearth/gql";
 import { useT } from "@reearth/i18n";
 import { useNotification } from "@reearth/state";
-
-export type AssetNodes = NonNullable<GetAssetsQuery["assets"]["nodes"][number]>[];
 
 export type AssetSortType = "date" | "name" | "size";
 
@@ -74,7 +71,21 @@ export default (teamId?: string, initialAssetUrl?: string | null, allowDeletion?
     data?.assets.pageInfo?.hasNextPage || data?.assets.pageInfo?.hasPreviousPage;
 
   const isRefetching = networkStatus === 3;
-  const assets = data?.assets.edges?.map(e => e.node) as AssetNodes;
+
+  const assets = data?.assets.edges
+    .map<Asset | undefined>(asset =>
+      asset.node
+        ? {
+            id: asset.node.id,
+            name: asset.node.name,
+            size: asset.node.size,
+            teamId: asset.node.teamId,
+            url: asset.node.url,
+            contentType: asset.node.contentType,
+          }
+        : undefined,
+    )
+    .filter((asset): asset is Asset => !!asset);
 
   const initialAsset = assets?.find(a => a.url === initialAssetUrl);
   const [selectedAssets, selectAsset] = useState<Asset[]>(initialAsset ? [initialAsset] : []);

--- a/src/components/organisms/Dashboard/hooks.ts
+++ b/src/components/organisms/Dashboard/hooks.ts
@@ -12,12 +12,9 @@ import {
   useCreateProjectMutation,
   useCreateSceneMutation,
   Visualizer,
-  GetProjectsQuery,
 } from "@reearth/gql";
 import { useT } from "@reearth/i18n";
 import { useTeam, useProject, useUnselectProject, useNotification } from "@reearth/state";
-
-export type ProjectNodes = NonNullable<GetProjectsQuery["projects"]["nodes"][number]>[];
 
 const projectsPerPage = 9;
 
@@ -117,25 +114,23 @@ export default (teamId?: string) => {
     notifyOnNetworkStatusChange: true,
   });
 
-  const projectNodes = projectData?.projects.edges.map(e => e.node) as ProjectNodes;
-
   const projects = useMemo(() => {
-    return (projectNodes ?? [])
+    return (projectData?.projects.edges ?? [])
       .map<Project | undefined>(project =>
-        project
+        project.node
           ? {
-              id: project.id,
-              description: project.description,
-              name: project.name,
-              image: project.imageUrl,
-              status: toPublishmentStatus(project.publishmentStatus),
-              isArchived: project.isArchived,
-              sceneId: project.scene?.id,
+              id: project.node.id,
+              description: project.node.description,
+              name: project.node.name,
+              image: project.node.imageUrl,
+              status: toPublishmentStatus(project.node.publishmentStatus),
+              isArchived: project.node.isArchived,
+              sceneId: project.node.scene?.id,
             }
           : undefined,
       )
       .filter((project): project is Project => !!project);
-  }, [projectNodes]);
+  }, [projectData?.projects.edges]);
 
   const hasMoreProjects =
     projectData?.projects.pageInfo?.hasNextPage || projectData?.projects.pageInfo?.hasPreviousPage;

--- a/src/components/organisms/Settings/Project/Dataset/hooks.ts
+++ b/src/components/organisms/Settings/Project/Dataset/hooks.ts
@@ -1,8 +1,8 @@
 import { useApolloClient } from "@apollo/client";
 import { useCallback } from "react";
 
+import { Item } from "@reearth/components/molecules/Settings/Project/Dataset/DatasetList";
 import {
-  DatasetsListQuery,
   useGetProjectSceneQuery,
   useImportDatasetMutation,
   useRemoveDatasetMutation,
@@ -10,10 +10,6 @@ import {
 } from "@reearth/gql";
 import { useT } from "@reearth/i18n";
 import { useTeam, useProject, useNotification } from "@reearth/state";
-
-type Nodes = NonNullable<DatasetsListQuery["datasetSchemas"]["nodes"]>;
-
-type DatasetSchemas = NonNullable<Nodes[number]>[];
 
 const datasetPerPage = 20;
 
@@ -38,9 +34,11 @@ export default (projectId: string) => {
     notifyOnNetworkStatusChange: true,
   });
 
-  const nodes = data?.datasetSchemas.edges.map(e => e.node) ?? [];
-
-  const datasetSchemas = nodes.filter(Boolean) as DatasetSchemas;
+  const datasetSchemas = data?.datasetSchemas.edges
+    .map<Item | undefined>(item =>
+      item.node ? { id: item.node.id, name: item.node.name } : undefined,
+    )
+    .filter((item): item is Item => !!item);
 
   const hasMoreDataSets =
     data?.datasetSchemas?.pageInfo.hasNextPage || data?.datasetSchemas?.pageInfo.hasPreviousPage;

--- a/src/components/organisms/Settings/Project/Public/hooks.ts
+++ b/src/components/organisms/Settings/Project/Public/hooks.ts
@@ -42,26 +42,27 @@ export default ({ projectId }: Params) => {
   });
 
   const rawProject = useMemo(
-    () => data?.projects.nodes.find(p => p?.id === projectId),
+    () => data?.projects.edges.find(p => p.node?.id === projectId),
     [data, projectId],
   );
+
   const project = useMemo(
     () =>
-      rawProject?.id
+      rawProject?.node?.id
         ? {
-            id: rawProject.id,
-            name: rawProject.name,
-            description: rawProject.description,
-            imageUrl: rawProject.imageUrl,
-            publicTitle: rawProject.publicTitle ?? undefined,
-            publicDescription: rawProject.publicDescription ?? undefined,
-            publicImage: rawProject.publicImage ?? undefined,
-            isArchived: rawProject.isArchived,
-            isBasicAuthActive: rawProject.isBasicAuthActive,
-            basicAuthUsername: rawProject.basicAuthUsername,
-            basicAuthPassword: rawProject.basicAuthPassword,
-            alias: rawProject.alias,
-            publishmentStatus: rawProject.publishmentStatus,
+            id: rawProject.node?.id,
+            name: rawProject.node?.name,
+            description: rawProject.node?.description,
+            imageUrl: rawProject.node?.imageUrl,
+            publicTitle: rawProject.node?.publicTitle ?? undefined,
+            publicDescription: rawProject.node?.publicDescription ?? undefined,
+            publicImage: rawProject.node?.publicImage ?? undefined,
+            isArchived: rawProject.node?.isArchived,
+            isBasicAuthActive: rawProject.node?.isBasicAuthActive,
+            basicAuthUsername: rawProject.node?.basicAuthUsername,
+            basicAuthPassword: rawProject.node?.basicAuthPassword,
+            alias: rawProject.node?.alias,
+            publishmentStatus: rawProject.node?.publishmentStatus,
           }
         : undefined,
     [rawProject],

--- a/src/components/organisms/Settings/Project/hooks.ts
+++ b/src/components/organisms/Settings/Project/hooks.ts
@@ -26,25 +26,26 @@ export default ({ projectId }: Params) => {
   });
 
   const rawProject = useMemo(
-    () => data?.projects.nodes.find(p => p?.id === projectId),
+    () => data?.projects.edges.find(p => p.node?.id === projectId),
     [data, projectId],
   );
+
   const project = useMemo(
     () =>
-      rawProject?.id
+      rawProject?.node?.id
         ? {
-            id: rawProject.id,
-            name: rawProject.name,
-            description: rawProject.description,
-            publicTitle: rawProject.publicTitle,
-            publicDescription: rawProject.publicDescription,
-            isArchived: rawProject.isArchived,
-            isBasicAuthActive: rawProject.isBasicAuthActive,
-            basicAuthUsername: rawProject.basicAuthUsername,
-            basicAuthPassword: rawProject.basicAuthPassword,
-            imageUrl: rawProject.imageUrl,
-            alias: rawProject.alias,
-            publishmentStatus: rawProject.publishmentStatus,
+            id: rawProject?.node?.id,
+            name: rawProject?.node?.name,
+            description: rawProject?.node?.description,
+            publicTitle: rawProject?.node?.publicTitle,
+            publicDescription: rawProject?.node?.publicDescription,
+            isArchived: rawProject?.node?.isArchived,
+            isBasicAuthActive: rawProject?.node?.isBasicAuthActive,
+            basicAuthUsername: rawProject?.node?.basicAuthUsername,
+            basicAuthPassword: rawProject?.node?.basicAuthPassword,
+            imageUrl: rawProject?.node?.imageUrl,
+            alias: rawProject?.node?.alias,
+            publishmentStatus: rawProject?.node?.publishmentStatus,
           }
         : undefined,
     [rawProject],

--- a/src/components/organisms/Settings/ProjectList/hooks.ts
+++ b/src/components/organisms/Settings/ProjectList/hooks.ts
@@ -10,19 +10,16 @@ import {
   useCreateSceneMutation,
   useGetProjectsQuery,
   Visualizer,
-  GetProjectsQuery,
 } from "@reearth/gql";
 import { useT } from "@reearth/i18n";
 import { useTeam, useProject, useNotification } from "@reearth/state";
 
-const toPublishmentStatus = (s: PublishmentStatus) =>
+const toPublishmentStatus = (s: PublishmentStatus | undefined) =>
   s === PublishmentStatus.Public
     ? "published"
     : s === PublishmentStatus.Limited
     ? "limited"
     : "unpublished";
-
-export type ProjectNodes = NonNullable<GetProjectsQuery["projects"]["nodes"][number]>[];
 
 const projectPerPage = 5;
 
@@ -65,19 +62,17 @@ export default (teamId: string) => {
     }
   }, [currentTeam, team, setTeam]);
 
-  const projectNodes = projectData?.projects.edges.map(e => e.node) as ProjectNodes;
-
-  const currentProjects = (projectNodes ?? [])
+  const currentProjects = projectData?.projects.edges
     .map<Project | undefined>(project =>
-      project
+      project.node
         ? {
-            id: project.id,
-            description: project.description,
-            name: project.name,
-            imageUrl: project.imageUrl,
-            isArchived: project.isArchived,
-            status: toPublishmentStatus(project.publishmentStatus),
-            sceneId: project.scene?.id,
+            id: project.node.id,
+            description: project.node.description,
+            name: project.node.name,
+            imageUrl: project.node.imageUrl,
+            isArchived: project.node.isArchived,
+            status: toPublishmentStatus(project.node.publishmentStatus),
+            sceneId: project.node.scene?.id,
           }
         : undefined,
     )

--- a/src/components/organisms/Settings/SettingPage/hooks.ts
+++ b/src/components/organisms/Settings/SettingPage/hooks.ts
@@ -66,10 +66,10 @@ export default (params: Params) => {
 
   useEffect(() => {
     if (!data) return;
-    const project = data?.projects.nodes.find(node => node?.id === params.projectId) ?? undefined;
+    const project = data?.projects.edges.find(e => e.node?.id === params.projectId) ?? undefined;
 
-    if (project?.id !== currentProject?.id) {
-      setProject(project);
+    if (project?.node?.id !== currentProject?.id) {
+      project?.node && setProject(project?.node);
     }
   }, [data, params, currentProject, setProject]);
 

--- a/src/gql/graphql-client-api.tsx
+++ b/src/gql/graphql-client-api.tsx
@@ -2366,7 +2366,7 @@ export type GetAssetsQueryVariables = Exact<{
 }>;
 
 
-export type GetAssetsQuery = { __typename?: 'Query', assets: { __typename?: 'AssetConnection', totalCount: number, edges: Array<{ __typename?: 'AssetEdge', cursor: string, node?: { __typename?: 'Asset', id: string, teamId: string, name: string, size: number, url: string, contentType: string } | null }>, nodes: Array<{ __typename?: 'Asset', id: string, teamId: string, name: string, size: number, url: string, contentType: string } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type GetAssetsQuery = { __typename?: 'Query', assets: { __typename?: 'AssetConnection', totalCount: number, edges: Array<{ __typename?: 'AssetEdge', cursor: string, node?: { __typename?: 'Asset', id: string, teamId: string, name: string, size: number, url: string, contentType: string } | null }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type CreateAssetMutationVariables = Exact<{
   teamId: Scalars['ID'];
@@ -2448,7 +2448,7 @@ export type DatasetsListQueryVariables = Exact<{
 }>;
 
 
-export type DatasetsListQuery = { __typename?: 'Query', datasetSchemas: { __typename?: 'DatasetSchemaConnection', totalCount: number, edges: Array<{ __typename?: 'DatasetSchemaEdge', node?: { __typename?: 'DatasetSchema', id: string, source: string, name: string } | null }>, nodes: Array<{ __typename?: 'DatasetSchema', id: string, source: string, name: string } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type DatasetsListQuery = { __typename?: 'Query', datasetSchemas: { __typename?: 'DatasetSchemaConnection', totalCount: number, edges: Array<{ __typename?: 'DatasetSchemaEdge', node?: { __typename?: 'DatasetSchema', id: string, source: string, name: string } | null }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type GetDatasetSchemasWithCountQueryVariables = Exact<{
   projectId: Scalars['ID'];
@@ -2715,7 +2715,7 @@ export type GetProjectsQueryVariables = Exact<{
 }>;
 
 
-export type GetProjectsQuery = { __typename?: 'Query', projects: { __typename?: 'ProjectConnection', totalCount: number, edges: Array<{ __typename?: 'ProjectEdge', node?: { __typename?: 'Project', id: string, name: string, description: string, imageUrl?: string | null, isArchived: boolean, isBasicAuthActive: boolean, basicAuthUsername: string, basicAuthPassword: string, publicTitle: string, publicDescription: string, publicImage: string, alias: string, publishmentStatus: PublishmentStatus, scene?: { __typename?: 'Scene', id: string } | null } | null }>, nodes: Array<{ __typename?: 'Project', id: string, name: string, description: string, imageUrl?: string | null, isArchived: boolean, isBasicAuthActive: boolean, basicAuthUsername: string, basicAuthPassword: string, publicTitle: string, publicDescription: string, publicImage: string, alias: string, publishmentStatus: PublishmentStatus, scene?: { __typename?: 'Scene', id: string } | null } | null>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type GetProjectsQuery = { __typename?: 'Query', projects: { __typename?: 'ProjectConnection', totalCount: number, edges: Array<{ __typename?: 'ProjectEdge', node?: { __typename?: 'Project', id: string, name: string, description: string, imageUrl?: string | null, isArchived: boolean, isBasicAuthActive: boolean, basicAuthUsername: string, basicAuthPassword: string, publicTitle: string, publicDescription: string, publicImage: string, alias: string, publishmentStatus: PublishmentStatus, scene?: { __typename?: 'Scene', id: string } | null } | null }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type CheckProjectAliasQueryVariables = Exact<{
   alias: Scalars['String'];
@@ -3869,14 +3869,6 @@ export const GetAssetsDocument = gql`
         contentType
       }
     }
-    nodes {
-      id
-      teamId
-      name
-      size
-      url
-      contentType
-    }
     pageInfo {
       endCursor
       hasNextPage
@@ -4292,11 +4284,6 @@ export const DatasetsListDocument = gql`
         source
         name
       }
-    }
-    nodes {
-      id
-      source
-      name
     }
     pageInfo {
       endCursor
@@ -5625,24 +5612,6 @@ export const GetProjectsDocument = gql`
         scene {
           id
         }
-      }
-    }
-    nodes {
-      id
-      name
-      description
-      imageUrl
-      isArchived
-      isBasicAuthActive
-      basicAuthUsername
-      basicAuthPassword
-      publicTitle
-      publicDescription
-      publicImage
-      alias
-      publishmentStatus
-      scene {
-        id
       }
     }
     pageInfo {

--- a/src/gql/queries/asset.ts
+++ b/src/gql/queries/asset.ts
@@ -14,14 +14,6 @@ export const GET_ASSETS = gql`
           contentType
         }
       }
-      nodes {
-        id
-        teamId
-        name
-        size
-        url
-        contentType
-      }
       pageInfo {
         endCursor
         hasNextPage

--- a/src/gql/queries/dataset.ts
+++ b/src/gql/queries/dataset.ts
@@ -76,11 +76,6 @@ export const GET_DATASETS_LIST = gql`
           name
         }
       }
-      nodes {
-        id
-        source
-        name
-      }
       pageInfo {
         endCursor
         hasNextPage

--- a/src/gql/queries/project.ts
+++ b/src/gql/queries/project.ts
@@ -52,24 +52,7 @@ export const GET_PROJECTS = gql`
           }
         }
       }
-      nodes {
-        id
-        name
-        description
-        imageUrl
-        isArchived
-        isBasicAuthActive
-        basicAuthUsername
-        basicAuthPassword
-        publicTitle
-        publicDescription
-        publicImage
-        alias
-        publishmentStatus
-        scene {
-          id
-        }
-      }
+
       pageInfo {
         endCursor
         hasNextPage


### PR DESCRIPTION
# Overview
The changes: 
1- Refactoring the queries of graphql  and remove nodes 
2- Modify all the queries on hooks 
3- Create (infinite scroll) wrapper atom and reuse it wherever the need for infinite scroll

## What I've done
The pages affected by this changes : 
1- Dashboard page 
2- setting pages : 
	1- Project list page 
	2- Assets page
	3- Datasets page
	4- setting page for each page 
	5- accessing pages from reearth-editor

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
