### PR TITLE
fix: layer select state not update properly

### DIFF
--- a/src/components/molecules/Visualizer/Plugin/context.tsx
+++ b/src/components/molecules/Visualizer/Plugin/context.tsx
@@ -172,8 +172,14 @@ export function Provider({
 
   useEmit<Pick<ReearthEventType, "cameramove" | "select">>(
     {
-      select: selectedLayer ? [selectedLayer.id] : [undefined],
-      cameramove: camera ? [camera] : undefined,
+      select: useMemo<[layerId: string | undefined]>(
+        () => (selectedLayer ? [selectedLayer.id] : [undefined]),
+        [selectedLayer],
+      ),
+      cameramove: useMemo<[camera: CameraPosition] | undefined>(
+        () => (camera ? [camera] : undefined),
+        [camera],
+      ),
     },
     emit,
   );

--- a/src/components/molecules/Visualizer/Plugin/context.tsx
+++ b/src/components/molecules/Visualizer/Plugin/context.tsx
@@ -172,7 +172,7 @@ export function Provider({
 
   useEmit<Pick<ReearthEventType, "cameramove" | "select">>(
     {
-      select: selectedLayer ? [selectedLayer.id] : undefined,
+      select: selectedLayer ? [selectedLayer.id] : [undefined],
       cameramove: camera ? [camera] : undefined,
     },
     emit,


### PR DESCRIPTION
# Overview

This PR fix three issues:

1. When create a new layer by drop the layer in Earth Editor, it doesn't got auto selected (No indicator shown on map).
   - This issue also lead to when create a new infobox for this layer the Infobox popup doesn't show automaticlly.
   - The bug comes from the state update: selectedLayer happens before layers data update so it got undefined.
   - Why it works before is bc the setLayers with new created object will lead to anothor selectedLayer update which can get the latest layers data.
   - In order to implement the update after layers data changed I replace the `useUpdate` with an internal implemtation (which refers to the source code of useUpdate but expose the state) and use the state as the dependence of `selectedLayer`.

2. When unselect a layer the plugin api `select` doesn't emit (the plugin will not be noticed as unselect).
   - For select event `undefined` is also meaningful and also should emit event to notice plugin there's no selected object. 

3. Plugin API event `select` `cameramove` emitted too much (not as expected i think).
   - The value of `args` (used as dependency of `useEffect` inside `useEmit`) is something like `[camera]` or `[selectedLayer.id]` which would be differect in each update and make the side effect trigger every time. For example if you add `cameramove` event from API then when you change any state eg. change scene background color you'll find the  event also emitted. Also if you add a `select` event and select a layer then when you move camera the `select` event keeps emitting.

## What I've done

- Replace `useUpdate` with a internal implement and use its state as `selectedLayer`'s dependency.
- Replace `undefined` to `[undefined]` in order to emit plugin api select event when unselect.
- Add useMemo to cache the array like `[camera]` and `[selectedLayer.id]` to avoid unnecessary emit.

## What I haven't done

## How I tested

- Create new layer from earth editor and create new infobox for it.
- Select & unselect layer and watch the event got with plugin.
- Add `select` `mousemove` event from plugin and watch the event emit.

## Screenshot

## Which point I want you to review particularly

## Memo
