### PR TITLE
fix: plugin widget's width using iframe's default

### DIFF
--- a/src/components/atoms/Plugin/IFrame/hooks.ts
+++ b/src/components/atoms/Plugin/IFrame/hooks.ts
@@ -111,7 +111,7 @@ export default function useHook({
                 ? typeof width === "number"
                   ? width
                   : width + "px"
-                : "html.offsetWidth + horizontalMargin + scrollbarW"
+                : "html.offsetWidth + horizontalMargin"
             };
             const height = ${
               height


### PR DESCRIPTION
# Overview
When plugin didn't set width in API call (reearth.on.show....) the width would fall back to the iframe's default 300px width, making content have to scroll.