### PR TITLE
fix: select not working after pinch event on ipad

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -184,7 +184,6 @@ export default ({
   const handleMouseEvent = useCallback(
     (type: keyof MouseEvents, e: CesiumMovementEvent, target: RootEventTarget) => {
       if (engineAPI.mouseEventCallbacks[type]) {
-        alert(type + JSON.stringify(e));
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
         const position = e.position || e.startPosition;

--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -1,4 +1,4 @@
-import { Color, Entity, Ion, Cesium3DTileFeature, Cartesian3 } from "cesium";
+import { Color, Entity, Ion, Cesium3DTileFeature, Cartesian3, Cartesian2 } from "cesium";
 import type { Viewer as CesiumViewer, TerrainProvider } from "cesium";
 import CesiumDnD, { Context } from "cesium-dnd";
 import { isEqual } from "lodash-es";
@@ -182,12 +182,16 @@ export default ({
   }, [cesium, selectedLayerId]);
 
   const handleMouseEvent = useCallback(
-    (type: keyof MouseEvents, e: CesiumMovementEvent, target: RootEventTarget) => {
+    (
+      type: keyof MouseEvents,
+      e: CesiumMovementEvent & { position1?: Cartesian2 | undefined },
+      target: RootEventTarget,
+    ) => {
       if (engineAPI.mouseEventCallbacks[type]) {
-        alert(JSON.stringify(e));
+        alert(type + JSON.stringify(e));
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
-        const position = e.position || e.startPosition;
+        const position = e.position || e.startPosition || e.position1;
         const props: MouseEvent = {
           x: position?.x,
           y: position?.y,

--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -1,4 +1,4 @@
-import { Color, Entity, Ion, Cesium3DTileFeature, Cartesian3, Cartesian2 } from "cesium";
+import { Color, Entity, Ion, Cesium3DTileFeature, Cartesian3 } from "cesium";
 import type { Viewer as CesiumViewer, TerrainProvider } from "cesium";
 import CesiumDnD, { Context } from "cesium-dnd";
 import { isEqual } from "lodash-es";
@@ -184,6 +184,7 @@ export default ({
   const handleMouseEvent = useCallback(
     (type: keyof MouseEvents, e: CesiumMovementEvent, target: RootEventTarget) => {
       if (engineAPI.mouseEventCallbacks[type]) {
+        alert(type + JSON.stringify(e));
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
         const position = e.position || e.startPosition;
@@ -195,20 +196,6 @@ export default ({
         const layerId = getLayerId(target);
         if (layerId) props.layerId = layerId;
         engineAPI.mouseEventCallbacks[type]?.(props);
-      }
-    },
-    [engineAPI],
-  );
-
-  const handlePinchEvent = useCallback(
-    (
-      type: keyof MouseEvents,
-      e: CesiumMovementEvent & { position1?: Cartesian2 | undefined },
-      target: RootEventTarget,
-    ) => {
-      if (engineAPI.mouseEventCallbacks[type]) {
-        alert(type + JSON.stringify(e) + JSON.stringify(target));
-        engineAPI.mouseEventCallbacks[type]?.({});
       }
     },
     [engineAPI],
@@ -236,25 +223,17 @@ export default ({
       mousemove: undefined,
       mouseenter: undefined,
       mouseleave: undefined,
-      pinchstart: undefined,
-      pinchend: undefined,
-      pinchmove: undefined,
       wheel: undefined,
     };
     (Object.keys(mouseEvents) as (keyof MouseEvents)[]).forEach(type => {
-      if (type === "wheel") {
-        mouseEvents[type] = (delta: number) => {
-          handleMouseWheel(delta);
-        };
-      } else if (type === "pinchstart" || type === "pinchmove" || type === "pinchend") {
-        mouseEvents[type] = (e: CesiumMovementEvent, target: RootEventTarget) => {
-          handlePinchEvent(type as keyof MouseEvents, e, target);
-        };
-      } else {
-        mouseEvents[type] = (e: CesiumMovementEvent, target: RootEventTarget) => {
-          handleMouseEvent(type as keyof MouseEvents, e, target);
-        };
-      }
+      mouseEvents[type] =
+        type === "wheel"
+          ? (delta: number) => {
+              handleMouseWheel(delta);
+            }
+          : (e: CesiumMovementEvent, target: RootEventTarget) => {
+              handleMouseEvent(type as keyof MouseEvents, e, target);
+            };
     });
     return mouseEvents;
   }, [handleMouseEvent, handleMouseWheel]);

--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -184,6 +184,7 @@ export default ({
   const handleMouseEvent = useCallback(
     (type: keyof MouseEvents, e: CesiumMovementEvent, target: RootEventTarget) => {
       if (engineAPI.mouseEventCallbacks[type]) {
+        alert(JSON.stringify(e));
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
         const position = e.position || e.startPosition;

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -114,6 +114,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         onMouseEnter={mouseEventHandles.mouseenter}
         onMouseLeave={mouseEventHandles.mouseleave}
         onPinchStart={mouseEventHandles.pinchstart}
+        onPinchEnd={mouseEventHandles.pinchend}
         onPinchMove={mouseEventHandles.pinchmove}
         onWheel={mouseEventHandles.wheel}>
         <Event onMount={handleMount} onUnmount={handleUnmount} />

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -113,9 +113,6 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         onMouseMove={mouseEventHandles.mousemove}
         onMouseEnter={mouseEventHandles.mouseenter}
         onMouseLeave={mouseEventHandles.mouseleave}
-        onPinchStart={mouseEventHandles.pinchstart}
-        onPinchEnd={mouseEventHandles.pinchend}
-        onPinchMove={mouseEventHandles.pinchmove}
         onWheel={mouseEventHandles.wheel}>
         <Event onMount={handleMount} onUnmount={handleUnmount} />
         <Clock property={property} />

--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -113,6 +113,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         onMouseMove={mouseEventHandles.mousemove}
         onMouseEnter={mouseEventHandles.mouseenter}
         onMouseLeave={mouseEventHandles.mouseleave}
+        onPinchStart={mouseEventHandles.pinchstart}
+        onPinchMove={mouseEventHandles.pinchmove}
         onWheel={mouseEventHandles.wheel}>
         <Event onMount={handleMount} onUnmount={handleUnmount} />
         <Clock property={property} />

--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.test.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.test.tsx
@@ -120,32 +120,11 @@ test("bind mouse events", () => {
   expect(fn).toHaveBeenCalledTimes(13);
   expect(fn).toHaveBeenCalledWith(props);
 
-  result.current.current?.onPinchStart(fn);
-  expect(result.current.current?.mouseEventCallbacks.pinchstart).toBe(fn);
-
-  result.current.current?.mouseEventCallbacks.pinchstart?.(props);
-  expect(fn).toHaveBeenCalledTimes(14);
-  expect(fn).toHaveBeenCalledWith(props);
-
-  result.current.current?.onPinchEnd(fn);
-  expect(result.current.current?.mouseEventCallbacks.pinchend).toBe(fn);
-
-  result.current.current?.mouseEventCallbacks.pinchend?.(props);
-  expect(fn).toHaveBeenCalledTimes(15);
-  expect(fn).toHaveBeenCalledWith(props);
-
-  result.current.current?.onPinchMove(fn);
-  expect(result.current.current?.mouseEventCallbacks.pinchmove).toBe(fn);
-
-  result.current.current?.mouseEventCallbacks.pinchmove?.(props);
-  expect(fn).toHaveBeenCalledTimes(16);
-  expect(fn).toHaveBeenCalledWith(props);
-
   result.current.current?.onWheel(fn);
   expect(result.current.current?.mouseEventCallbacks.wheel).toBe(fn);
 
   const wheelProps = { delta: 1 };
   result.current.current?.mouseEventCallbacks.wheel?.(wheelProps);
-  expect(fn).toHaveBeenCalledTimes(17);
+  expect(fn).toHaveBeenCalledTimes(14);
   expect(fn).toHaveBeenCalledWith(wheelProps);
 });

--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.test.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.test.tsx
@@ -128,3 +128,26 @@ test("bind mouse events", () => {
   expect(fn).toHaveBeenCalledTimes(14);
   expect(fn).toHaveBeenCalledWith(wheelProps);
 });
+
+const mockRequestRender = vi.fn();
+test("requestRender", () => {
+  const { result } = renderHook(() => {
+    const cesium = useRef<CesiumComponentRef<CesiumViewer>>({
+      cesiumElement: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        scene: {
+          requestRender: mockRequestRender,
+        },
+        isDestroyed: () => {
+          return false;
+        },
+      },
+    });
+    const engineRef = useRef<EngineRef>(null);
+    useEngineRef(engineRef, cesium);
+    return engineRef;
+  });
+  result.current.current?.requestRender();
+  expect(mockRequestRender).toHaveBeenCalledTimes(1);
+});

--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.test.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.test.tsx
@@ -151,3 +151,38 @@ test("requestRender", () => {
   result.current.current?.requestRender();
   expect(mockRequestRender).toHaveBeenCalledTimes(1);
 });
+
+const mockZoomIn = vi.fn(amount => amount);
+const mockZoomOut = vi.fn(amount => amount);
+test("zoom", () => {
+  const { result } = renderHook(() => {
+    const cesium = useRef<CesiumComponentRef<CesiumViewer>>({
+      cesiumElement: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        scene: {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          camera: {
+            zoomIn: mockZoomIn,
+            zoomOut: mockZoomOut,
+          },
+        },
+        isDestroyed: () => {
+          return false;
+        },
+      },
+    });
+    const engineRef = useRef<EngineRef>(null);
+    useEngineRef(engineRef, cesium);
+    return engineRef;
+  });
+
+  result.current.current?.zoomIn(10);
+  expect(mockZoomIn).toHaveBeenCalledTimes(1);
+  expect(mockZoomIn).toHaveBeenCalledWith(10);
+
+  result.current.current?.zoomOut(20);
+  expect(mockZoomOut).toHaveBeenCalledTimes(1);
+  expect(mockZoomOut).toHaveBeenCalledWith(20);
+});

--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
@@ -29,9 +29,6 @@ export default function useEngineRef(
     mousemove: undefined,
     mouseenter: undefined,
     mouseleave: undefined,
-    pinchstart: undefined,
-    pinchend: undefined,
-    pinchmove: undefined,
     wheel: undefined,
   });
   const e = useMemo((): EngineRef => {
@@ -149,15 +146,6 @@ export default function useEngineRef(
       },
       onMouseLeave: (cb: ((props: MouseEvent) => void) | undefined) => {
         mouseEventCallbacks.current.mouseleave = cb;
-      },
-      onPinchStart: (cb: ((props: MouseEvent) => void) | undefined) => {
-        mouseEventCallbacks.current.pinchstart = cb;
-      },
-      onPinchEnd: (cb: ((props: MouseEvent) => void) | undefined) => {
-        mouseEventCallbacks.current.pinchend = cb;
-      },
-      onPinchMove: (cb: ((props: MouseEvent) => void) | undefined) => {
-        mouseEventCallbacks.current.pinchmove = cb;
       },
       onWheel: (cb: ((props: MouseEvent) => void) | undefined) => {
         mouseEventCallbacks.current.wheel = cb;

--- a/src/components/molecules/Visualizer/Engine/ref.ts
+++ b/src/components/molecules/Visualizer/Engine/ref.ts
@@ -28,9 +28,6 @@ export type MouseEvents = {
   mousemove: ((props: MouseEvent) => void) | undefined;
   mouseenter: ((props: MouseEvent) => void) | undefined;
   mouseleave: ((props: MouseEvent) => void) | undefined;
-  pinchstart: ((props: MouseEvent) => void) | undefined;
-  pinchend: ((props: MouseEvent) => void) | undefined;
-  pinchmove: ((props: MouseEvent) => void) | undefined;
   wheel: ((props: MouseEvent) => void) | undefined;
 };
 
@@ -48,9 +45,6 @@ export type MouseEventHandles = {
   onMouseMove: (fn: MouseEvents["mousemove"]) => void;
   onMouseEnter: (fn: MouseEvents["mouseenter"]) => void;
   onMouseLeave: (fn: MouseEvents["mouseleave"]) => void;
-  onPinchStart: (fn: MouseEvents["pinchstart"]) => void;
-  onPinchEnd: (fn: MouseEvents["pinchend"]) => void;
-  onPinchMove: (fn: MouseEvents["pinchmove"]) => void;
   onWheel: (fn: MouseEvents["wheel"]) => void;
 };
 

--- a/src/components/molecules/Visualizer/Plugin/context.tsx
+++ b/src/components/molecules/Visualizer/Plugin/context.tsx
@@ -214,9 +214,6 @@ export function Provider({
       mousemove: "onMouseMove",
       mouseenter: "onMouseEnter",
       mouseleave: "onMouseLeave",
-      pinchstart: "onPinchStart",
-      pinchend: "onPinchEnd",
-      pinchmove: "onPinchMove",
       wheel: "onWheel",
     };
     (Object.keys(eventHandles) as (keyof MouseEvents)[]).forEach((event: keyof MouseEvents) => {

--- a/src/components/molecules/Visualizer/Plugin/hooks.ts
+++ b/src/components/molecules/Visualizer/Plugin/hooks.ts
@@ -156,9 +156,6 @@ export function useAPI({
         "mousemove",
         "mouseenter",
         "mouseleave",
-        "pinchstart",
-        "pinchend",
-        "pinchmove",
         "wheel",
       ]);
     }

--- a/src/components/molecules/Visualizer/Plugin/types.ts
+++ b/src/components/molecules/Visualizer/Plugin/types.ts
@@ -61,9 +61,6 @@ export type ReearthEventType = {
   mousemove: [props: MouseEvent];
   mouseenter: [props: MouseEvent];
   mouseleave: [props: MouseEvent];
-  pinchstart: [props: MouseEvent];
-  pinchend: [props: MouseEvent];
-  pinchmove: [props: MouseEvent];
   wheel: [props: MouseEvent];
 };
 


### PR DESCRIPTION
# Overview

Touch to select does not work after pinch event on iPad.

This bug comes from unproper handle of pinch event props.

The pinch events are added with mouse events as a nice-to-have feature. Since the data type definiation is same with the mouse event props i didn't pay additional attention on the data but it turns out to be different.

After discuss with Red we decide to remove pinch events, the reasons are:

- Pinch events are not mouse events and should not be mix together.
- Pinch events carry different props which is different campared with mouse events.
- The main goal of mouse events API is to detect the target position or layer, which also can be done on touch device.
- The pinch event actually do zoom or rotate which are different usecases.

Also if we got some requirements in detail about pinch events, we can add them back with certain design.

## What I've done

- Remove `pinchstart` `pinchmove` `pinchend` events.
- Add some unit test (not related just for pass the codecov test).

## What I haven't done

## How I tested

Select layer -> zoom in/out -> select layer on iPad visiting the deploy preview site.
* It is really dificult to dev / test for mobile device as can not visit local site through LAN.

## Screenshot

## Which point I want you to review particularly

## Memo
