### PR TITLE
fix: iframe scripts are not loaded with order

### DIFF
--- a/src/components/atoms/Plugin/IFrame/hooks.ts
+++ b/src/components/atoms/Plugin/IFrame/hooks.ts
@@ -131,7 +131,7 @@ export default function useHook({
 
     doc.body.innerHTML = html;
 
-    const onLoaded = () => {
+    const onScriptsLoaded = () => {
       // post pending messages
       if (pendingMesages.current.length) {
         for (const msg of pendingMesages.current) {
@@ -148,9 +148,9 @@ export default function useHook({
     if (scripts) {
       execScripts(scripts, false)
         .finally(() => execScripts(scripts, true))
-        .finally(onLoaded);
+        .finally(onScriptsLoaded);
     } else {
-      onLoaded();
+      onScriptsLoaded();
     }
   }, [autoResizeMessageKey, html, onLoad, height, width]);
 

--- a/src/components/atoms/Plugin/IFrame/hooks.ts
+++ b/src/components/atoms/Plugin/IFrame/hooks.ts
@@ -146,8 +146,7 @@ export default function useHook({
           return chain.then(() => runScript(oldScript));
         }, Promise.resolve())
         .finally(() => {
-          loaded.current = true;
-          onLoad?.();
+          onLoaded();
           Array.from(scripts)
             .filter(
               script =>
@@ -155,23 +154,27 @@ export default function useHook({
                 script.getAttribute("async") ||
                 script.getAttribute("defer"),
             )
-            .reduce((chain, oldScript) => {
-              return chain.then(() => runScript(oldScript));
-            }, Promise.resolve());
+            .forEach(oldScript => {
+              runScript(oldScript);
+            });
         });
     }
 
-    // post pending messages
-    if (pendingMesages.current.length) {
-      for (const msg of pendingMesages.current) {
-        win.postMessage(msg, "*");
+    const onLoaded = () => {
+      // post pending messages
+      if (pendingMesages.current.length) {
+        for (const msg of pendingMesages.current) {
+          win.postMessage(msg, "*");
+        }
+        pendingMesages.current = [];
       }
-      pendingMesages.current = [];
-    }
 
-    if (!scripts) {
       loaded.current = true;
       onLoad?.();
+    };
+
+    if (!scripts) {
+      onLoaded();
     }
   }, [autoResizeMessageKey, html, onLoad, height, width]);
 

--- a/src/components/atoms/Plugin/IFrame/hooks.ts
+++ b/src/components/atoms/Plugin/IFrame/hooks.ts
@@ -131,8 +131,9 @@ export default function useHook({
 
     doc.body.innerHTML = html;
 
-    // exec
+    // exec scripts
     const scripts = doc.body.querySelectorAll("script");
+
     if (scripts) {
       Array.from(scripts)
         .filter(


### PR DESCRIPTION
# Overview

We used a `forEach` to trigger the execute of script inside a plugin iframe html which will lose the loading order like it is handled in a normal browser. 

## What I've done

- Replace the code with a Promise for each script so that the scripts can load in order.
- The scripts with attribute `async` `defer` or has `type="module"` (which will be handled as defer by browser) will be loaded last.
- Updated the `onLoad` part. This should be emitted after sync scripts loaded or there's no script.

## What I haven't done

## How I tested

- Test with plateauview plugin which use cdn React & ReactDOM.

## Screenshot

Before:
![image](https://user-images.githubusercontent.com/21994748/183819137-5fd48285-ebc0-4472-a987-e384351f5b1e.png)

After:
![image](https://user-images.githubusercontent.com/21994748/183819242-ae8018e9-aace-48e5-abc1-216742eb86b6.png)

Btw the assets issue is not related with this.

## Which point I want you to review particularly

## Memo
