### PR TITLE
feat: add 3D OSM building tiles

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -52,6 +52,7 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
       ? tileset
       : null;
   }, [isVisible, sourceType, tileset]);
+  
   return !isVisible || (!tileset && !sourceType) || !tilesetUrl ? null : (
     <Cesium3DTileset
       ref={ref}

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -1,4 +1,8 @@
-import { Cesium3DTileset as Cesium3DTilesetType, Cesium3DTileStyle } from "cesium";
+import {
+  Cesium3DTileset as Cesium3DTilesetType,
+  Cesium3DTileStyle,
+  createOsmBuildings,
+} from "cesium";
 import { useCallback, useEffect, useState } from "react";
 import { Cesium3DTileset, CesiumComponentRef, useCesium } from "resium";
 
@@ -9,6 +13,7 @@ export type Props = PrimitiveProps<Property>;
 
 export type Property = {
   default?: {
+    sourceType?: "url" | "OSM";
     tileset?: string;
     styleUrl?: string;
     shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
@@ -18,7 +23,8 @@ export type Property = {
 export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Element | null {
   const { viewer } = useCesium();
   const { isVisible, property } = layer ?? {};
-  const { tileset, styleUrl, shadows } = (property as Property | undefined)?.default ?? {};
+  const { sourceType, tileset, styleUrl, shadows } =
+    (property as Property | undefined)?.default ?? {};
   const [style, setStyle] = useState<Cesium3DTileStyle>();
 
   const ref = useCallback(
@@ -41,6 +47,17 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
       setStyle(new Cesium3DTileStyle(await res.json()));
     })();
   }, [styleUrl]);
+  console.log(sourceType);
+  useEffect(() => {
+    const osmTile = createOsmBuildings();
+    if (sourceType == "OSM") {
+      viewer?.scene.primitives.add(osmTile);
+    } else viewer?.scene.primitives.remove(osmTile);
+    // } else {
+    //   osmTile = createOsmBuildings();
+    //   viewer?.scene.primitives.remove(createOsmBuildings());
+    // }
+  }, [isVisible, sourceType, viewer?.scene.primitives]);
 
   return !isVisible || !tileset ? null : (
     <Cesium3DTileset

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -1,9 +1,5 @@
-import {
-  Cesium3DTileset as Cesium3DTilesetType,
-  Cesium3DTileStyle,
-  createOsmBuildings,
-} from "cesium";
-import { useCallback, useEffect, useState } from "react";
+import { Cesium3DTileset as Cesium3DTilesetType, Cesium3DTileStyle, IonResource } from "cesium";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Cesium3DTileset, CesiumComponentRef, useCesium } from "resium";
 
 import type { Props as PrimitiveProps } from "../../../Primitive";
@@ -13,7 +9,7 @@ export type Props = PrimitiveProps<Property>;
 
 export type Property = {
   default?: {
-    sourceType?: "url" | "OSM";
+    sourceType?: "url" | "osm";
     tileset?: string;
     styleUrl?: string;
     shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
@@ -47,22 +43,18 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
       setStyle(new Cesium3DTileStyle(await res.json()));
     })();
   }, [styleUrl]);
-  console.log(sourceType);
-  useEffect(() => {
-    const osmTile = createOsmBuildings();
-    if (sourceType == "OSM") {
-      viewer?.scene.primitives.add(osmTile);
-    } else viewer?.scene.primitives.remove(osmTile);
-    // } else {
-    //   osmTile = createOsmBuildings();
-    //   viewer?.scene.primitives.remove(createOsmBuildings());
-    // }
-  }, [isVisible, sourceType, viewer?.scene.primitives]);
-
-  return !isVisible || !tileset ? null : (
+  const tilesetUrl = useMemo(() => {
+    return sourceType === "osm" && isVisible
+      ? IonResource.fromAssetId(96188)
+      : sourceType === "url" && isVisible
+      ? tileset
+      : null;
+  }, [isVisible, sourceType, tileset]);
+  console.log(tilesetUrl);
+  return !isVisible || (!tileset && !sourceType) || !tilesetUrl ? null : (
     <Cesium3DTileset
       ref={ref}
-      url={tileset}
+      url={tilesetUrl}
       style={style}
       shadows={shadowMode(shadows)}
       onReady={_debugFlight ? t => viewer?.zoomTo(t) : undefined}

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -46,8 +46,8 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
 
   const tilesetUrl = useMemo(() => {
     return sourceType === "osm" && isVisible
-      ? //https://github.com/CesiumGS/cesium/blob/1.69/Source/Scene/createOsmBuildings.js#L50
-        IonResource.fromAssetId(96188)
+      ?
+        IonResource.fromAssetId(96188) //https://github.com/CesiumGS/cesium/blob/1.69/Source/Scene/createOsmBuildings.js#L50
       : sourceType === "url" && isVisible && tileset
       ? tileset
       : null;

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -46,7 +46,8 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
 
   const tilesetUrl = useMemo(() => {
     return sourceType === "osm" && isVisible
-      ? IonResource.fromAssetId(96188)
+      ? //https://github.com/CesiumGS/cesium/blob/1.69/Source/Scene/createOsmBuildings.js#L50
+        IonResource.fromAssetId(96188)
       : sourceType === "url" && isVisible && tileset
       ? tileset
       : null;

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -50,7 +50,6 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
       ? tileset
       : null;
   }, [isVisible, sourceType, tileset]);
-  console.log(tilesetUrl);
   return !isVisible || (!tileset && !sourceType) || !tilesetUrl ? null : (
     <Cesium3DTileset
       ref={ref}

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -46,7 +46,7 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
   const tilesetUrl = useMemo(() => {
     return sourceType === "osm" && isVisible
       ? IonResource.fromAssetId(96188)
-      : sourceType === "url" && isVisible
+      : sourceType === "url" && isVisible && tileset
       ? tileset
       : null;
   }, [isVisible, sourceType, tileset]);

--- a/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/Tileset/index.tsx
@@ -43,6 +43,7 @@ export default function Tileset({ layer }: PrimitiveProps<Property>): JSX.Elemen
       setStyle(new Cesium3DTileStyle(await res.json()));
     })();
   }, [styleUrl]);
+
   const tilesetUrl = useMemo(() => {
     return sourceType === "osm" && isVisible
       ? IonResource.fromAssetId(96188)


### PR DESCRIPTION
# Overview
OSM Buildings is a 3D buildings layer covering the entire world. It's available as a 3D Tileset on Cesium.
we modified reearth  in way that allows the user to add OSM building 3d Tileset as a layer.
## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
backend pr : https://github.com/reearth/reearth/pull/340