### PR TITLE
fix: exposed plugin api add layer does not return layer id

### DIFF
--- a/src/components/molecules/Visualizer/Plugin/api.ts
+++ b/src/components/molecules/Visualizer/Plugin/api.ts
@@ -64,13 +64,12 @@ export function exposed({
         }),
         layers: merge(commonReearth.layers, {
           get add() {
-            return (layer: Layer, parentId?: string) => {
+            return (layer: Layer, parentId?: string) =>
               commonReearth.layers.add(
                 layer,
                 parentId,
                 plugin ? `${plugin.id}/${plugin.extensionId}` : "",
               );
-            };
           },
         }),
         ui: {


### PR DESCRIPTION
# Overview

The exposed API `reearth.layers.add` doesn't return the new layer's id as expected.

## What I've done

Add return value to the exposed add function.

## How I tested

Tested with plugin:

```
const id = reearth.layers.add({extension:'marker'});
console.log(id);
```
