### PR TITLE
fix: fix the story telling icon size when the layer name is too long 

### DIFF
--- a/src/components/molecules/Visualizer/Widget/Storytelling/index.tsx
+++ b/src/components/molecules/Visualizer/Widget/Storytelling/index.tsx
@@ -208,6 +208,7 @@ const Title = styled(Text)<{ color: string }>`
 const StyledIcon = styled(Icon)<{ iconColor: string }>`
   color: ${({ color }) => color};
   margin-right: ${metricsSizes["l"]}px;
+  flex-shrink: 0;
 `;
 
 const MenuIcon = styled(Icon)<{ menuOpen?: boolean; publishedTheme: PublishTheme }>`


### PR DESCRIPTION
# Overview
For the story telling , when the user change the layer name and make it too long the icon became too small 
![image](https://user-images.githubusercontent.com/89770889/197706995-5660f716-318b-4124-89c1-1e613b09a2ee.png)

## What I've done


## What I haven't done

## How I tested


## Screenshot
![image](https://user-images.githubusercontent.com/89770889/197707064-e47a08f8-0960-4d49-813b-34994831d87d.png)

## Which point I want you to review particularly

## Memo
