### PR TITLE
feat: support acquiring locations with terrain

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/common.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/common.ts
@@ -151,11 +151,25 @@ export const vo = (
     [""]: undefined,
   }[o || ""]);
 
-export const getLocationFromScreenXY = (scene: Scene | undefined | null, x: number, y: number) => {
+export const getLocationFromScreenXY = (
+  scene: Scene | undefined | null,
+  x: number,
+  y: number,
+  withTerrain = false,
+) => {
   if (!scene) return undefined;
   const camera = scene.camera;
   const ellipsoid = scene.globe.ellipsoid;
-  const cartesian = camera?.pickEllipsoid(new Cartesian2(x, y), ellipsoid);
+  let cartesian;
+  if (withTerrain) {
+    const ray = camera.getPickRay(new Cartesian2(x, y));
+    if (ray) {
+      cartesian = scene.globe.pick(ray, scene);
+    }
+  }
+  if (!cartesian) {
+    cartesian = camera?.pickEllipsoid(new Cartesian2(x, y), ellipsoid);
+  }
   if (!cartesian) return undefined;
   const { latitude, longitude, height } = ellipsoid.cartesianToCartographic(cartesian);
   return {

--- a/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/hooks.ts
@@ -213,7 +213,9 @@ export default ({
         const props: MouseEvent = {
           x: position?.x,
           y: position?.y,
-          ...(position ? getLocationFromScreenXY(viewer.scene, position.x, position.y) ?? {} : {}),
+          ...(position
+            ? getLocationFromScreenXY(viewer.scene, position.x, position.y, true) ?? {}
+            : {}),
         };
         const layerId = getLayerId(target);
         if (layerId) props.layerId = layerId;


### PR DESCRIPTION
# Overview

Mouse events want to get the correct location when terrain is on.

## What I've done

Update the common `getLocationFromScreenXY` function, added a prop `withTerrain` default as `false`.

If `withTerrain` is `true` it will use `globe.pick` instead of `camera.pickEllipsoid` so that terrain can take effect. And if doesn't get the location it will still try `camera.pickEllipsoid` as a polyfill.

## What I haven't done

## How I tested

Tested with plugin using mouse event.

## Screenshot

![image](https://user-images.githubusercontent.com/21994748/198926290-8771f5ec-423f-4ffe-9e6c-fdd716ea50b0.png)


## Which point I want you to review particularly

## Memo
