### PR TITLE
fix: correct flyToGround destination camera

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/common.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/common.ts
@@ -597,7 +597,7 @@ export function moveRight(scene: Scene, amount: number) {
 export async function moveOverTerrain(viewer: Viewer, offset = 0) {
   const camera = getCamera(viewer);
   if (camera?.lng === undefined || camera?.lat === undefined) return;
-  const height = await sampleTerrainHeight(viewer.scene, camera?.lng, camera?.lat);
+  const height = await sampleTerrainHeight(viewer.scene, camera.lng, camera.lat);
   if (height && height !== 0) {
     const innerCamera = getCamera(viewer);
     if (innerCamera && innerCamera?.height < height + offset) {

--- a/src/components/molecules/Visualizer/Engine/Cesium/common.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/common.ts
@@ -619,11 +619,10 @@ export async function flyToGround(
   if (camera.lng === undefined || camera.lat === undefined) return;
   const height = await sampleTerrainHeight(viewer.scene, camera.lng, camera.lat);
   const tarHeight = height ? height + offset : offset;
-  const groundCamera = { ...camera, height: tarHeight };
   cancelCameraFlight.current?.();
   cancelCameraFlight.current = flyTo(
     viewer.scene?.camera,
-    { ...getCamera(viewer), ...groundCamera },
+    { ...getCamera(viewer), ...camera, height: tarHeight },
     options,
   );
 }


### PR DESCRIPTION
# Overview

The `flyToGround` API used a wrong destination camera. 

## What I've done

Correct the destination camera using the param camera.

## What I haven't done

## How I tested

Test with plugin pedestrain.

## Screenshot

## Which point I want you to review particularly

## Memo
