### PR TITLE
fix: rename animation option to withoutAnimation in lookAt

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
+++ b/src/components/molecules/Visualizer/Engine/Cesium/useEngineRef.ts
@@ -81,7 +81,7 @@ export default function useEngineRef(
       lookAt: (camera, options) => {
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
-        if (options?.animation) {
+        if (options?.withoutAnimation) {
           return lookAtWithoutAnimation(viewer.scene, { ...getCamera(viewer), ...camera });
         }
         cancelCameraFlight.current?.();

--- a/src/components/molecules/Visualizer/Engine/ref.ts
+++ b/src/components/molecules/Visualizer/Engine/ref.ts
@@ -126,7 +126,7 @@ export type CameraOptions = {
   /** Seconds */
   duration?: number;
   easing?: (time: number) => number;
-  animation?: boolean;
+  withoutAnimation?: boolean;
 };
 
 export type ClusterProps = {


### PR DESCRIPTION
# Overview

I added `animation` option to lookAt function. This option makes lookAt function work without animation.
But the name that called `animation` is miss context, so I fixed this name to `withoutAnimation`.
https://github.com/reearth/reearth-web/pull/338/files#diff-0b5055db5c2f9046c0a43a5d935daac31c9eff33ee864fe1f90cc7f890932e09R84

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
