### PR TITLE
perf: improve unnecessary loading the globe image

### DIFF
--- a/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
+++ b/src/components/molecules/Visualizer/Engine/Cesium/index.tsx
@@ -88,7 +88,6 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       homeButton={false}
       geocoder={false}
       infoBox={false}
-      imageryProvider={false}
       baseLayerPicker={false}
       navigationHelpButton={false}
       projectionPicker={false}

--- a/src/core/engines/Cesium/index.tsx
+++ b/src/core/engines/Cesium/index.tsx
@@ -89,7 +89,6 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
         homeButton={false}
         geocoder={false}
         infoBox={false}
-        imageryProvider={false}
         baseLayerPicker={false}
         navigationHelpButton={false}
         projectionPicker={false}


### PR DESCRIPTION
# Overview

## What I've done

I removed `imageryProvider={false}` props for Viewer component.
This props removes the loaded globe image. The props is used in [here](https://github.com/reearth/resium/blob/41070fb25b32e9a18e09814b615b8728a51214b8/src/Viewer/Viewer.ts#L143).
Therefore this cause unnecessary loading globe image when the Viewer component is re-rendered.

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
