### PR TITLE
feat: support multi feature for geojson

### DIFF
--- a/src/core/mantle/data/geojson.ts
+++ b/src/core/mantle/data/geojson.ts
@@ -16,6 +16,40 @@ export function processGeoJSON(geojson: GeoJSON, range?: DataRange): Feature[] {
 
   if (geojson.type === "Feature") {
     const geo = geojson.geometry;
+    if (geo.type === "MultiPoint") {
+      return geo.coordinates.flatMap(coord => {
+        return processGeoJSON({
+          ...geojson,
+          geometry: {
+            type: "Point",
+            coordinates: coord,
+          },
+        });
+      });
+    }
+    if (geo.type === "MultiLineString") {
+      return geo.coordinates.flatMap(coord => {
+        return processGeoJSON({
+          ...geojson,
+          geometry: {
+            type: "LineString",
+            coordinates: coord,
+          },
+        });
+      });
+    }
+    if (geo.type === "MultiPolygon") {
+      return geo.coordinates.flatMap(coord => {
+        return processGeoJSON({
+          ...geojson,
+          geometry: {
+            type: "Polygon",
+            coordinates: coord,
+          },
+        });
+      });
+    }
+
     return [
       {
         id: (geojson.id && String(geojson.id)) || generateRandomString(12),

--- a/src/core/mantle/types/index.ts
+++ b/src/core/mantle/types/index.ts
@@ -1,4 +1,11 @@
-import type { LineString, Point, Polygon } from "geojson";
+import type {
+  LineString,
+  Point,
+  Polygon,
+  MultiPoint,
+  MultiLineString,
+  MultiPolygon,
+} from "geojson";
 
 import type { Infobox, Block, Tag } from "../compat/types";
 
@@ -71,7 +78,7 @@ export type Feature = {
   range?: DataRange;
 };
 
-export type Geometry = Point | LineString | Polygon;
+export type Geometry = Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon;
 
 export type ComputedLayerStatus = "fetching" | "ready";
 


### PR DESCRIPTION
# Overview

## What I've done

I've supported the multi feature for geojson.
The multi feature includes `MultiPoint`, `MultiLineString` and `MultiPolygon`.

## What I haven't done

## How I tested

You can use the following sample geojson.
1. Download the sample
2. Set it to `.storybook/public`
3. Set the path in `core/engine/Cesium/index.stories.tsx`

[sample.zip](https://github.com/reearth/reearth-web/files/10255142/sample.zip)

## Screenshot

## Which point I want you to review particularly

## Memo
