### PR TITLE
fix: missing type of API modal & popup options. 

### DIFF
--- a/src/components/molecules/Visualizer/Plugin/api.ts
+++ b/src/components/molecules/Visualizer/Plugin/api.ts
@@ -130,11 +130,11 @@ export function exposed({
         modal: {
           show: (
             html: string,
-            options?:
-              | {
-                  background?: string;
-                }
-              | undefined,
+            options?: {
+              width?: number | string;
+              height?: number | string;
+              background?: string;
+            },
           ) => {
             renderModal(html, options);
           },
@@ -145,12 +145,12 @@ export function exposed({
         popup: {
           show: (
             html: string,
-            options:
-              | {
-                  position?: PopupPosition;
-                  offset?: number;
-                }
-              | undefined,
+            options?: {
+              width?: number | string;
+              height?: number | string;
+              position?: PopupPosition;
+              offset?: number;
+            },
           ) => {
             renderPopup(html, options);
           },


### PR DESCRIPTION
# Overview

There's a type missing on function `exposed` modal.show / popup.show options. 
It doesn't effect the functionality but better to correct it anyway.

## What I've done

Add missing types.

## What I haven't done

## How I tested

Test with plugin:
[modalpopup.zip](https://github.com/reearth/reearth-web/files/10443695/modalpopup.zip)

## Screenshot

## Which point I want you to review particularly

## Memo
