### PR TITLE
feat: support overriding czml appearance on reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Resource/index.stories.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.stories.tsx
@@ -27,6 +27,13 @@ Default.args = {
         url: "/testdata/sample.czml",
       },
       resource: {},
+      marker: {
+        pointColor: {
+          expression: {
+            conditions: [["${id} === '1'", "color('red')"]],
+          },
+        },
+      },
     },
   ],
   property: {

--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -28,8 +28,8 @@ const comps = {
 };
 
 const delegatingAppearance: Record<keyof typeof comps, (keyof AppearanceTypes)[]> = {
-  kml: [],
-  geojson: [],
+  kml: ["marker", "polyline", "polygon"],
+  geojson: ["marker", "polyline", "polygon"],
   czml: ["marker", "polyline", "polygon"],
 };
 

--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -4,7 +4,7 @@ import {
   GeoJsonDataSource as CesiumGeoJsonDataSource,
 } from "cesium";
 import { useCallback, useMemo } from "react";
-import { KmlDataSource, CzmlDataSource, GeoJsonDataSource } from "resium";
+import { KmlDataSource, CzmlDataSource, GeoJsonDataSource, useCesium } from "resium";
 
 import { evalFeature } from "@reearth/core/mantle";
 
@@ -41,6 +41,7 @@ export default function Resource({ isVisible, property, layer }: Props) {
     const url = property?.url;
     return [type ?? (data?.type as ResourceAppearance["type"]), url ?? data?.url];
   }, [property, layer]);
+  const { viewer } = useCesium();
 
   const ext = useMemo(
     () => (!type || type === "auto" ? url?.match(/\.([a-z]+?)(?:\?.*?)?$/) : undefined),
@@ -52,9 +53,9 @@ export default function Resource({ isVisible, property, layer }: Props) {
 
   const handleOnChange = useCallback(
     (e: CesiumCzmlDataSource | CesiumKmlDataSource | CesiumGeoJsonDataSource) => {
-      attachStyle(e, appearances, layer, evalFeature);
+      attachStyle(e, appearances, layer, evalFeature, viewer);
     },
-    [appearances, layer],
+    [appearances, layer, viewer],
   );
 
   if (!isVisible || !Component || !url) return null;

--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -53,7 +53,7 @@ export default function Resource({ isVisible, property, layer }: Props) {
 
   const handleOnChange = useCallback(
     (e: CesiumCzmlDataSource | CesiumKmlDataSource | CesiumGeoJsonDataSource) => {
-      attachStyle(e, appearances, layer, evalFeature, viewer);
+      attachStyle(e, appearances, layer, evalFeature, viewer.clock.currentTime);
     },
     [appearances, layer, viewer],
   );

--- a/src/core/engines/Cesium/Feature/Resource/utils.test.ts
+++ b/src/core/engines/Cesium/Feature/Resource/utils.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "vitest";
+
+import { heightReference, shadowMode } from "../../common";
+import { toColor } from "../utils";
+
+import { attachProperties } from "./utils";
+
+test("attachProperties()", () => {
+  const mockEntity: any = {
+    polygon: {
+      outlineWidth: 100,
+      material: toColor("blue"),
+    },
+  };
+  const mockComputedFeature: any = {
+    polygon: {
+      fillColor: "red",
+      shadows: "enabled",
+      heightReference: "clamp",
+    },
+  };
+
+  attachProperties(mockEntity, mockComputedFeature, ["polygon", "polygon"], {
+    material: {
+      name: "fillColor",
+      type: "color",
+    },
+    outlineWidth: {
+      name: "strokeWidth",
+    },
+    shadows: {
+      name: "shadows",
+      type: "shadows",
+    },
+    heightReference: {
+      name: "heightReference",
+      type: "heightReference",
+    },
+  });
+
+  expect(mockEntity.polygon).toEqual({
+    material: toColor("red"),
+    shadows: shadowMode("enabled"),
+    heightReference: heightReference("clamp"),
+    outlineWidth: 100,
+  });
+  expect(mockEntity.properties.reearth_originalProperties).toEqual({
+    polygon: {
+      material: toColor("blue"),
+      outlineWidth: 100,
+    },
+  });
+
+  // Computed feature should not be changed.
+  expect(mockComputedFeature).toEqual({
+    polygon: {
+      fillColor: "red",
+      shadows: "enabled",
+      heightReference: "clamp",
+    },
+  });
+});

--- a/src/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/src/core/engines/Cesium/Feature/Resource/utils.ts
@@ -6,7 +6,6 @@ import {
   Entity,
   Cartesian3,
   PolygonHierarchy,
-  Viewer,
 } from "cesium";
 
 import { AppearanceTypes, ComputedFeature, ComputedLayer, Feature } from "@reearth/core/mantle";
@@ -101,7 +100,7 @@ export const attachStyle = (
   appearances: (keyof AppearanceTypes)[] | undefined,
   layer: ComputedLayer | undefined,
   evalFeature: EvalFeature,
-  viewer: Viewer,
+  currentTime: JulianDate,
 ) => {
   if (!layer) {
     return;
@@ -113,7 +112,7 @@ export const attachStyle = (
       }
 
       if (appearance === "marker") {
-        const position = entity.position?.getValue(viewer.clock.currentTime);
+        const position = entity.position?.getValue(currentTime);
         const coordinates = [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0];
         const feature: Feature = {
           type: "feature",

--- a/src/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/src/core/engines/Cesium/Feature/Resource/utils.ts
@@ -6,6 +6,7 @@ import {
   Entity,
   Cartesian3,
   PolygonHierarchy,
+  Viewer,
 } from "cesium";
 
 import { AppearanceTypes, ComputedFeature, ComputedLayer, Feature } from "@reearth/core/mantle";
@@ -100,6 +101,7 @@ export const attachStyle = (
   appearances: (keyof AppearanceTypes)[] | undefined,
   layer: ComputedLayer | undefined,
   evalFeature: EvalFeature,
+  viewer: Viewer,
 ) => {
   if (!layer) {
     return;
@@ -111,7 +113,7 @@ export const attachStyle = (
       }
 
       if (appearance === "marker") {
-        const position = entity.position?.getValue(JulianDate.now());
+        const position = entity.position?.getValue(viewer.clock.currentTime);
         const coordinates = [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0];
         const feature: Feature = {
           type: "feature",

--- a/src/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/src/core/engines/Cesium/Feature/Resource/utils.ts
@@ -1,0 +1,245 @@
+import {
+  KmlDataSource as CesiumKmlDataSource,
+  CzmlDataSource as CesiumCzmlDataSource,
+  GeoJsonDataSource as CesiumGeoJsonDataSource,
+  JulianDate,
+  Entity,
+  Cartesian3,
+  PolygonHierarchy,
+} from "cesium";
+
+import { AppearanceTypes, ComputedFeature, ComputedLayer, Feature } from "@reearth/core/mantle";
+import { EvalFeature } from "@reearth/core/Map";
+
+import { heightReference, shadowMode, toColor } from "../../common";
+import { attachTag, getTag, Tag } from "../utils";
+
+export function overrideOriginalProperties(
+  entity: Entity,
+  tag: Tag | undefined,
+  name: string,
+  properties: any,
+) {
+  const originalProperties = tag?.originalProperties || {};
+  attachTag(entity, {
+    ...(tag || {}),
+    originalProperties: {
+      ...originalProperties,
+      [name]: {
+        ...originalProperties[name],
+        ...properties,
+      },
+    },
+  });
+}
+
+type CesiumEntityAppearanceKey = "polygon" | "polyline";
+type SupportedAppearanceKey = "marker" | keyof Pick<Entity, CesiumEntityAppearanceKey>;
+
+type EntityAppearanceKey<AName extends SupportedAppearanceKey> = AName extends "marker"
+  ? keyof Pick<Entity, "point">
+  : keyof Pick<Entity, CesiumEntityAppearanceKey>;
+
+type AppearancePropertyKeyType = "color" | "heightReference" | "shadows";
+
+export function attachProperties<
+  AName extends SupportedAppearanceKey,
+  PName extends EntityAppearanceKey<AName>,
+>(
+  entity: Entity,
+  computedFeature: ComputedFeature | undefined,
+  namePair: [appearanceName: AName, propertyName: PName],
+  propertyMap: {
+    [K in keyof Exclude<Entity[PName], undefined>]?: {
+      name: keyof AppearanceTypes[AName];
+      type?: AppearancePropertyKeyType;
+    };
+  },
+) {
+  const [appearanceName, propertyName] = namePair;
+  const property = entity[propertyName];
+  if (!property) {
+    return;
+  }
+
+  const tag = getTag(entity);
+
+  // Backup original properties
+  overrideOriginalProperties(
+    entity,
+    tag,
+    propertyName,
+    Object.keys(propertyMap).reduce((r, k) => {
+      r[k] = (property as any)[k];
+      return r;
+    }, {} as Record<string, any>),
+  );
+
+  Object.entries(propertyMap).forEach(([entityPropertyKey, appearancePropertyKey]) => {
+    const appearanceKeyName = appearancePropertyKey.name;
+    const appearanceKeyType = appearancePropertyKey.type as AppearancePropertyKeyType;
+
+    let value = (computedFeature?.[appearanceName] as any)?.[appearanceKeyName];
+    switch (appearanceKeyType) {
+      case "color":
+        value = toColor(value);
+        break;
+      case "shadows":
+        value = shadowMode(value);
+        break;
+      case "heightReference":
+        value = heightReference(value);
+    }
+
+    (property as any)[entityPropertyKey] = value ?? (property as any)[entityPropertyKey];
+  });
+}
+
+export const attachStyle = (
+  dataSource: CesiumKmlDataSource | CesiumCzmlDataSource | CesiumGeoJsonDataSource,
+  appearances: (keyof AppearanceTypes)[] | undefined,
+  layer: ComputedLayer | undefined,
+  evalFeature: EvalFeature,
+) => {
+  if (!layer) {
+    return;
+  }
+  dataSource?.entities.values.forEach(entity => {
+    appearances?.forEach(appearance => {
+      if (layer?.layer.type == "simple" && !layer?.layer?.[appearance]) {
+        return;
+      }
+
+      if (appearance === "marker") {
+        const position = entity.position?.getValue(JulianDate.now());
+        const coordinates = [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0];
+        const feature: Feature = {
+          type: "feature",
+          id: entity.id,
+          geometry: {
+            type: "Point",
+            coordinates,
+          },
+          properties: entity.properties?.getValue(JulianDate.now()) || {},
+          range: {
+            x: coordinates[0],
+            y: coordinates[1],
+            z: coordinates[2],
+          },
+        };
+        const computedFeature = evalFeature(layer.layer, feature);
+        attachProperties(entity, computedFeature, ["marker", "point"], {
+          pixelSize: {
+            name: "pointSize",
+          },
+          color: {
+            name: "pointColor",
+            type: "color",
+          },
+          outlineColor: {
+            name: "pointOutlineColor",
+            type: "color",
+          },
+          outlineWidth: {
+            name: "pointOutlineWidth",
+          },
+          heightReference: {
+            name: "heightReference",
+            type: "heightReference",
+          },
+        });
+      }
+
+      if (appearance === "polyline") {
+        const entityPosition = entity.position?.getValue(JulianDate.now());
+        const positions = entity.polyline?.positions?.getValue(JulianDate.now()) as Cartesian3[];
+        const coordinates = positions?.map(position => [
+          position?.x ?? 0,
+          position?.y ?? 0,
+          position?.z ?? 0,
+        ]);
+        const feature: Feature = {
+          type: "feature",
+          id: entity.id,
+          geometry: {
+            type: "LineString",
+            coordinates,
+          },
+          properties: entity.properties || {},
+          range: {
+            x: entityPosition?.x ?? 0,
+            y: entityPosition?.y ?? 0,
+            z: entityPosition?.z ?? 0,
+          },
+        };
+        const computedFeature = evalFeature(layer.layer, feature);
+        attachProperties(entity, computedFeature, ["polyline", "polyline"], {
+          width: {
+            name: "strokeWidth",
+          },
+          material: {
+            name: "strokeColor",
+            type: "color",
+          },
+          shadows: {
+            name: "shadows",
+            type: "shadows",
+          },
+          clampToGround: {
+            name: "clampToGround",
+          },
+        });
+      }
+
+      if (appearance === "polygon") {
+        const entityPosition = entity.position?.getValue(JulianDate.now());
+        const hierarchy = entity.polygon?.hierarchy?.getValue(JulianDate.now()) as PolygonHierarchy;
+        const coordinates = hierarchy.holes?.map(hole =>
+          hole.positions.map(position => [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0]),
+        );
+        const feature: Feature = {
+          type: "feature",
+          id: entity.id,
+          geometry: {
+            type: "Polygon",
+            coordinates,
+          },
+          properties: entity.properties || {},
+          range: {
+            x: entityPosition?.x ?? 0,
+            y: entityPosition?.y ?? 0,
+            z: entityPosition?.z ?? 0,
+          },
+        };
+        const computedFeature = evalFeature(layer.layer, feature);
+        attachProperties(entity, computedFeature, ["polygon", "polygon"], {
+          fill: {
+            name: "fill",
+          },
+          material: {
+            name: "fillColor",
+            type: "color",
+          },
+          outline: {
+            name: "stroke",
+          },
+          outlineColor: {
+            name: "strokeColor",
+            type: "color",
+          },
+          outlineWidth: {
+            name: "strokeWidth",
+          },
+          shadows: {
+            name: "shadows",
+            type: "shadows",
+          },
+          heightReference: {
+            name: "heightReference",
+            type: "heightReference",
+          },
+        });
+      }
+    });
+  });
+};

--- a/src/core/engines/Cesium/Feature/utils.tsx
+++ b/src/core/engines/Cesium/Feature/utils.tsx
@@ -43,6 +43,7 @@ export type Tag = {
   draggable?: boolean;
   unselectable?: boolean;
   legacyLocationPropertyKey?: string;
+  originalProperties?: any;
 };
 
 export const EntityExt = forwardRef(EntityExtComponent);
@@ -93,7 +94,8 @@ export function attachTag(
     entity.properties = new PropertyBag();
   }
   for (const k of tagKeys) {
-    if (!(k in tag)) entity.properties.removeProperty(`reearth_${k}`);
+    if (!(k in tag) && entity.properties.hasProperty(`reearth_${k}`))
+      entity.properties.removeProperty(`reearth_${k}`);
     else entity.properties[`reearth_${k}`] = tag[k];
   }
 }
@@ -128,6 +130,7 @@ const tagObj: { [k in keyof Tag]: 1 } = {
   featureId: 1,
   layerId: 1,
   unselectable: 1,
+  originalProperties: 1,
 };
 
 const tagKeys = Object.keys(tagObj) as (keyof Tag)[];


### PR DESCRIPTION
# Overview

I implemented overriding  czml appearance support on reearth/core.

## What I've done


## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
