### PR TITLE
chore: add offline_access auth scope to support refresh tokens with built-in auth server (#425

### DIFF
--- a/src/auth/provider.tsx
+++ b/src/auth/provider.tsx
@@ -12,7 +12,7 @@ const Provider: React.FC<{ children?: ReactNode }> = ({ children }) => {
       clientId={clientId}
       audience={audience}
       useRefreshTokens
-      scope="openid profile email"
+      scope="openid profile email offline_access"
       cacheLocation="localstorage"
       redirectUri={window.location.origin}>
       {children}


### PR DESCRIPTION
Add `offline_access` scpe to support refresh tokens with built-in auth server