### PR TITLE
fix: GeoJSON with resource appearance on reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -6,7 +6,7 @@ import {
 import { useCallback, useMemo } from "react";
 import { KmlDataSource, CzmlDataSource, GeoJsonDataSource, useCesium } from "resium";
 
-import { evalFeature } from "@reearth/core/mantle";
+import { DataType, evalFeature } from "@reearth/core/mantle";
 
 import type { ResourceAppearance, AppearanceTypes } from "../../..";
 import { extractSimpleLayerData, type FeatureComponentConfig, type FeatureProps } from "../utils";
@@ -33,13 +33,18 @@ const delegatingAppearance: Record<keyof typeof comps, (keyof AppearanceTypes)[]
   czml: ["marker", "polyline", "polygon"],
 };
 
+const DataTypeListAllowsOnlyProperty: DataType[] = ["geojson"];
+
 export default function Resource({ isVisible, property, layer }: Props) {
   const { clampToGround } = property ?? {};
   const [type, url] = useMemo((): [ResourceAppearance["type"], string | undefined] => {
     const data = extractSimpleLayerData(layer);
     const type = property?.type;
     const url = property?.url;
-    return [type ?? (data?.type as ResourceAppearance["type"]), url ?? data?.url];
+    return [
+      type ?? (data?.type as ResourceAppearance["type"]),
+      url ?? (data && !DataTypeListAllowsOnlyProperty.includes(data.type) ? data?.url : undefined),
+    ];
   }, [property, layer]);
   const { viewer } = useCesium();
 


### PR DESCRIPTION
# Overview

Resource feature component load geojson even if geojson is already rendered by other appearance like marker.
So I fixed this bugs.

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
