### PR TITLE
fix: use default infobox on reearth/core

### DIFF
--- a/src/core/Crust/Plugins/api.ts
+++ b/src/core/Crust/Plugins/api.ts
@@ -475,7 +475,10 @@ export function commonReearth({
         return layerSelectionReason();
       },
       get overriddenInfobox() {
-        return layerSelectionReason()?.overriddenInfobox;
+        return layerSelectionReason()?.defaultInfobox;
+      },
+      get defaultInfobox() {
+        return layerSelectionReason()?.defaultInfobox;
       },
       get selected() {
         return selectedLayer();

--- a/src/core/Crust/Plugins/plugin_types.ts
+++ b/src/core/Crust/Plugins/plugin_types.ts
@@ -16,7 +16,7 @@ import type {
   LookAtDestination,
   LayerSelectionReason,
   LazyLayer,
-  OverriddenInfobox,
+  DefaultInfobox,
   OverriddenLayer,
   Undefinable,
   WrappedRef,
@@ -80,7 +80,9 @@ export type Reearth = {
         reason?: LayerSelectionReason | undefined,
       ) => void;
       selectionReason?: LayerSelectionReason;
-      overriddenInfobox?: LayerSelectionReason["overriddenInfobox"];
+      // For compat
+      overriddenInfobox?: LayerSelectionReason["defaultInfobox"];
+      defaultInfobox?: LayerSelectionReason["defaultInfobox"];
       tags?: Tag[];
       layers?: LazyLayer[];
       isLayer?: boolean;
@@ -222,7 +224,7 @@ export type Plugins = {
 
 export type SelectLayerOptions = {
   reason?: string;
-  overriddenInfobox?: OverriddenInfobox;
+  defaultInfobox?: DefaultInfobox;
 };
 
 /** The API for iframes, which is required not only for displaying the UI but also for calling the browser API. */

--- a/src/core/Map/Layers/hooks.ts
+++ b/src/core/Map/Layers/hooks.ts
@@ -65,7 +65,7 @@ export type Ref = {
   overriddenLayers: () => OverriddenLayer[];
 };
 
-export type OverriddenInfobox = {
+export type DefaultInfobox = {
   title?: string;
   content: { key: string; value: string }[];
 };
@@ -74,12 +74,12 @@ export type OverriddenLayer = Omit<Layer, "type" | "children">;
 
 export type LayerSelectionReason = {
   reason?: string;
-  overriddenInfobox?: OverriddenInfobox;
+  defaultInfobox?: DefaultInfobox;
 };
 
 export type FeatureSelectionReason = {
   reason?: string;
-  overriddenInfobox?: OverriddenInfobox;
+  defaultInfobox?: DefaultInfobox;
 };
 
 export default function useHooks({

--- a/src/core/Map/Layers/index.tsx
+++ b/src/core/Map/Layers/index.tsx
@@ -18,7 +18,7 @@ export type {
   Ref,
   NaiveLayer,
   LayerSelectionReason,
-  OverriddenInfobox,
+  DefaultInfobox,
   OverriddenLayer,
 } from "./hooks";
 export type {

--- a/src/core/Map/index.tsx
+++ b/src/core/Map/index.tsx
@@ -17,7 +17,7 @@ export type {
   LayerSelectionReason,
   Cluster,
   EvalFeature,
-  OverriddenInfobox,
+  DefaultInfobox,
   OverriddenLayer,
 } from "./Layers";
 

--- a/src/core/engines/Cesium/hooks.ts
+++ b/src/core/engines/Cesium/hooks.ts
@@ -201,7 +201,7 @@ export default ({
       const tag = getTag(entity);
       if (tag) {
         onLayerSelect?.(tag.layerId, String(tag.featureId), {
-          overriddenInfobox: {
+          defaultInfobox: {
             title: entity.getProperty("name"),
             content: tileProperties(entity),
           },
@@ -295,7 +295,7 @@ export default ({
         const tag = getTag(target);
         if (tag) {
           onLayerSelect?.(tag.layerId, String(tag.featureId), {
-            overriddenInfobox: {
+            defaultInfobox: {
               title: target.getProperty("name"),
               content: tileProperties(target),
             },


### PR DESCRIPTION
# Overview

## What I've done

- Renamed overriddenInfobox to defaultInfobox
- Changed overriddenInfobox not to override infobox, and it should behave as default value

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
