### PR TITLE
feat: add preserveDrawingBuffer as webgl option

### DIFF
--- a/src/core/engines/Cesium/index.tsx
+++ b/src/core/engines/Cesium/index.tsx
@@ -126,7 +126,8 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
       onMouseMove={mouseEventHandles.mousemove}
       onMouseEnter={mouseEventHandles.mouseenter}
       onMouseLeave={mouseEventHandles.mouseleave}
-      onWheel={mouseEventHandles.wheel}>
+      onWheel={mouseEventHandles.wheel}
+      contextOptions={{ webgl: { preserveDrawingBuffer: true } }}>
       <Event onMount={handleMount} onUnmount={handleUnmount} />
       <Clock property={property} onTick={handleTick} />
       <ImageryLayers tiles={property?.tiles} cesiumIonAccessToken={cesiumIonAccessToken} />


### PR DESCRIPTION
# Overview

This PR tries to fix the issue that saving screen get black image.

Please also check the previous PR of [adding captureScreen API](https://github.com/reearth/reearth-web/pull/310).

I was thinking about two approaches when add this API:
- A: add preserveDrawingBuffer:true to webgl content options.
- B: call canvas.toDataURL immediately after a render.

I choose B since A seems [has side effect on perfermance](https://stackoverflow.com/questions/27746091/preservedrawingbuffer-false-is-it-worth-the-effort).

Recently we find the bug that saved image is all black, so i want to apply solution A to make the API more stable.

BUT: test using this preview deploy can still reproduce the issue sometimes.

## What I've done

Add `{ webgl: { preserveDrawingBuffer: true } }` to Viewer contentOptions.

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
