### PR TITLE
feat: support distanceDisplayCondition on reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Box/Edge.tsx
+++ b/src/core/engines/Cesium/Feature/Box/Edge.tsx
@@ -4,6 +4,7 @@ import {
   Color,
   TimeIntervalCollection,
   TranslationRotationScale,
+  DistanceDisplayCondition,
 } from "cesium";
 import { FC, memo } from "react";
 import { PolylineGraphics } from "resium";
@@ -37,6 +38,7 @@ type Props = {
   hoverColor?: Color;
   width?: number;
   availability?: TimeIntervalCollection;
+  distanceDisplayCondition?: DistanceDisplayCondition;
   onMouseDown?: EdgeEventCallback;
   onMouseMove?: EdgeEventCallback;
   onMouseUp?: EdgeEventCallback;
@@ -55,6 +57,7 @@ export const Edge: FC<Props> = memo(function EdgePresenter({
   width,
   hoverColor,
   availability,
+  distanceDisplayCondition,
   onMouseDown,
   onMouseMove,
   onMouseUp,
@@ -79,6 +82,7 @@ export const Edge: FC<Props> = memo(function EdgePresenter({
         width={width}
         material={outlineColor}
         arcType={ArcType.NONE}
+        distanceDisplayCondition={distanceDisplayCondition}
       />
     </EntityExt>
   );

--- a/src/core/engines/Cesium/Feature/Box/ScalePoints.tsx
+++ b/src/core/engines/Cesium/Feature/Box/ScalePoints.tsx
@@ -4,6 +4,7 @@ import {
   Color,
   TimeIntervalCollection,
   TranslationRotationScale,
+  DistanceDisplayCondition,
 } from "cesium";
 import { FC, memo } from "react";
 import { BoxGraphics, PolylineGraphics } from "resium";
@@ -50,6 +51,7 @@ type Props = {
   visiblePoint?: boolean;
   visibleAxisLine?: boolean;
   availability?: TimeIntervalCollection;
+  distanceDisplayCondition?: DistanceDisplayCondition;
   onPointMouseDown?: PointEventCallback;
   onPointMouseMove?: PointEventCallback;
   onPointMouseUp?: PointEventCallback;
@@ -72,6 +74,7 @@ export const ScalePoints: FC<Props> = memo(function ScalePointsPresenter({
   visiblePoint,
   visibleAxisLine,
   availability,
+  distanceDisplayCondition,
   onPointMouseDown,
   onPointMouseMove,
   onPointMouseUp,
@@ -113,6 +116,7 @@ export const ScalePoints: FC<Props> = memo(function ScalePointsPresenter({
           outline={!!pointOutlineColor}
           outlineColor={pointOutlineColorCb}
           outlineWidth={pointOutlineWidth}
+          distanceDisplayCondition={distanceDisplayCondition}
         />
       </EntityExt>
       <EntityExt
@@ -129,6 +133,7 @@ export const ScalePoints: FC<Props> = memo(function ScalePointsPresenter({
           outline={!!pointOutlineColor}
           outlineColor={pointOutlineColorCb}
           outlineWidth={pointOutlineWidth}
+          distanceDisplayCondition={distanceDisplayCondition}
         />
       </EntityExt>
       <EntityExt
@@ -141,6 +146,7 @@ export const ScalePoints: FC<Props> = memo(function ScalePointsPresenter({
           material={axisColorProperty}
           width={axisLineWidth}
           arcType={ArcType.NONE}
+          distanceDisplayCondition={distanceDisplayCondition}
         />
       </EntityExt>
     </>

--- a/src/core/engines/Cesium/Feature/Box/Side.tsx
+++ b/src/core/engines/Cesium/Feature/Box/Side.tsx
@@ -1,5 +1,6 @@
 import {
   Color,
+  DistanceDisplayCondition,
   Plane as CesiumPlane,
   TimeIntervalCollection,
   TranslationRotationScale,
@@ -22,6 +23,7 @@ export const Side: FC<{
   activeOutlineColor?: Color;
   fill?: boolean;
   availability?: TimeIntervalCollection;
+  distanceDisplayCondition?: DistanceDisplayCondition;
 }> = memo(function SidePresenter({
   layerId,
   featureId,
@@ -33,6 +35,7 @@ export const Side: FC<{
   activeOutlineColor,
   trs,
   availability,
+  distanceDisplayCondition,
 }) {
   const { cbRef, plane, dimension, orientation, outlineColorCb } = useHooks({
     planeLocal,
@@ -56,6 +59,7 @@ export const Side: FC<{
         material={fillColor}
         outlineWidth={1}
         outlineColor={outlineColorCb}
+        distanceDisplayCondition={distanceDisplayCondition}
         outline
       />
     </EntityExt>

--- a/src/core/engines/Cesium/Feature/Box/hooks/box.ts
+++ b/src/core/engines/Cesium/Feature/Box/hooks/box.ts
@@ -299,8 +299,8 @@ export const useHooks = ({
 
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return {

--- a/src/core/engines/Cesium/Feature/Box/hooks/box.ts
+++ b/src/core/engines/Cesium/Feature/Box/hooks/box.ts
@@ -13,7 +13,12 @@ import { useCesium } from "resium";
 import type { Property } from "..";
 import { sampleTerrainHeightFromCartesian } from "../../../common";
 import { useContext } from "../../context";
-import { type FeatureProps, toColor, toTimeInterval } from "../../utils";
+import {
+  type FeatureProps,
+  toColor,
+  toTimeInterval,
+  toDistanceDisplayCondition,
+} from "../../utils";
 import type { EdgeEventCallback } from "../Edge";
 import type { PointEventCallback } from "../ScalePoints";
 import { computeMouseMoveAmount, updateTrs } from "../utils";
@@ -293,12 +298,17 @@ export const useHooks = ({
   }, [cursor]);
 
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return {
     style,
     trs,
     scalePointStyle,
     availability,
+    distanceDisplayCondition,
     handlePointMouseDown,
     handlePointMouseMove,
     handlePointMouseUp,

--- a/src/core/engines/Cesium/Feature/Box/index.tsx
+++ b/src/core/engines/Cesium/Feature/Box/index.tsx
@@ -41,6 +41,7 @@ const Box: React.FC<Props> = memo(function BoxPresenter({
     trs,
     scalePointStyle,
     availability,
+    distanceDisplayCondition,
     handlePointMouseDown,
     handlePointMouseMove,
     handlePointMouseUp,
@@ -68,6 +69,7 @@ const Box: React.FC<Props> = memo(function BoxPresenter({
           activeOutlineColor={style.activeOutlineColor}
           trs={trs}
           availability={availability}
+          distanceDisplayCondition={distanceDisplayCondition}
         />
       ))}
       {BOX_EDGES.map((edge, i) => {
@@ -89,6 +91,7 @@ const Box: React.FC<Props> = memo(function BoxPresenter({
             onMouseMove={edge.isDraggable ? handleEdgeMouseMove : undefined}
             onMouseUp={edge.isDraggable ? handleEdgeMouseUp : undefined}
             availability={availability}
+            distanceDisplayCondition={distanceDisplayCondition}
           />
         );
       })}
@@ -119,6 +122,7 @@ const Box: React.FC<Props> = memo(function BoxPresenter({
             onPointMouseMove={handlePointMouseMove}
             onPointMouseUp={handlePointMouseUp}
             availability={availability}
+            distanceDisplayCondition={distanceDisplayCondition}
           />
         ))}
     </>

--- a/src/core/engines/Cesium/Feature/Ellipsoid/index.tsx
+++ b/src/core/engines/Cesium/Feature/Ellipsoid/index.tsx
@@ -54,8 +54,8 @@ export default function Ellipsoid({ id, isVisible, property, geometry, layer, fe
   const material = useMemo(() => toColor(fillColor), [fillColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return !isVisible || !pos ? null : (

--- a/src/core/engines/Cesium/Feature/Ellipsoid/index.tsx
+++ b/src/core/engines/Cesium/Feature/Ellipsoid/index.tsx
@@ -9,6 +9,7 @@ import type { EllipsoidAppearance } from "../../..";
 import { heightReference, shadowMode } from "../../common";
 import {
   EntityExt,
+  toDistanceDisplayCondition,
   toTimeInterval,
   type FeatureComponentConfig,
   type FeatureProps,
@@ -52,6 +53,10 @@ export default function Ellipsoid({ id, isVisible, property, geometry, layer, fe
 
   const material = useMemo(() => toColor(fillColor), [fillColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return !isVisible || !pos ? null : (
     <EntityExt
@@ -67,6 +72,7 @@ export default function Ellipsoid({ id, isVisible, property, geometry, layer, fe
         material={material}
         heightReference={heightReference(hr)}
         shadows={shadowMode(shadows)}
+        distanceDisplayCondition={distanceDisplayCondition}
       />
     </EntityExt>
   );

--- a/src/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/src/core/engines/Cesium/Feature/Marker/index.tsx
@@ -8,6 +8,7 @@ import type { MarkerAppearance } from "../../..";
 import { useIcon, ho, vo, heightReference, toColor } from "../../common";
 import {
   EntityExt,
+  toDistanceDisplayCondition,
   toTimeInterval,
   type FeatureComponentConfig,
   type FeatureProps,
@@ -124,6 +125,10 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
   );
 
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return !pos || !isVisible ? null : (
     <>
@@ -137,6 +142,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             positions={extrudePoints}
             material={extrudePointsLineColor}
             width={0.5}
+            distanceDisplayCondition={distanceDisplayCondition}
           />
         </EntityExt>
       )}
@@ -154,6 +160,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             outlineColor={pointOutlineColorCesium}
             outlineWidth={pointOutlineWidth}
             heightReference={heightReference(hr)}
+            distanceDisplayCondition={distanceDisplayCondition}
           />
         ) : (
           <BillboardGraphics
@@ -162,6 +169,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             horizontalOrigin={ho(horizontalOrigin)}
             verticalOrigin={vo(verticalOrigin)}
             heightReference={heightReference(hr)}
+            distanceDisplayCondition={distanceDisplayCondition}
           />
         )}
         {label && (
@@ -188,6 +196,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             backgroundColor={labelBackgroundColorCesium}
             backgroundPadding={labelBackgroundPadding}
             heightReference={heightReference(hr)}
+            distanceDisplayCondition={distanceDisplayCondition}
           />
         )}
       </EntityExt>

--- a/src/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/src/core/engines/Cesium/Feature/Marker/index.tsx
@@ -126,8 +126,8 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
 
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return !pos || !isVisible ? null : (

--- a/src/core/engines/Cesium/Feature/Model/index.tsx
+++ b/src/core/engines/Cesium/Feature/Model/index.tsx
@@ -83,8 +83,8 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
   const modelSilhouetteColor = useMemo(() => toColor(silhouetteColor), [silhouetteColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return !isVisible || (!model && !url) || !position ? null : (

--- a/src/core/engines/Cesium/Feature/Model/index.tsx
+++ b/src/core/engines/Cesium/Feature/Model/index.tsx
@@ -8,6 +8,7 @@ import type { ModelAppearance } from "../../..";
 import { colorBlendMode, heightReference, shadowMode } from "../../common";
 import {
   EntityExt,
+  toDistanceDisplayCondition,
   toTimeInterval,
   type FeatureComponentConfig,
   type FeatureProps,
@@ -81,6 +82,10 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
   const modelLightColor = useMemo(() => toColor(lightColor), [lightColor]);
   const modelSilhouetteColor = useMemo(() => toColor(silhouetteColor), [silhouetteColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return !isVisible || (!model && !url) || !position ? null : (
     <EntityExt
@@ -105,6 +110,7 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
         heightReference={heightReference(hr)}
         maximumScale={maximumScale}
         minimumPixelSize={minimumPixelSize}
+        distanceDisplayCondition={distanceDisplayCondition}
       />
     </EntityExt>
   );

--- a/src/core/engines/Cesium/Feature/PhotoOverlay/index.tsx
+++ b/src/core/engines/Cesium/Feature/PhotoOverlay/index.tsx
@@ -11,6 +11,7 @@ import type { LegacyPhotooverlayAppearance } from "../../..";
 import { heightReference, ho, useIcon, vo } from "../../common";
 import {
   EntityExt,
+  toDistanceDisplayCondition,
   toTimeInterval,
   type FeatureComponentConfig,
   type FeatureProps,
@@ -85,6 +86,10 @@ export default function PhotoOverlay({
   });
 
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return !isVisible || !pos ? null : (
     <>
@@ -100,6 +105,7 @@ export default function PhotoOverlay({
           horizontalOrigin={ho(imageHorizontalOrigin)}
           verticalOrigin={vo(imageVerticalOrigin)}
           heightReference={heightReference(hr)}
+          distanceDisplayCondition={distanceDisplayCondition}
         />
       </EntityExt>
       {photoOverlayImageTransiton === "unmounted" ? null : (

--- a/src/core/engines/Cesium/Feature/PhotoOverlay/index.tsx
+++ b/src/core/engines/Cesium/Feature/PhotoOverlay/index.tsx
@@ -87,8 +87,8 @@ export default function PhotoOverlay({
 
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return !isVisible || !pos ? null : (

--- a/src/core/engines/Cesium/Feature/Polygon/index.tsx
+++ b/src/core/engines/Cesium/Feature/Polygon/index.tsx
@@ -11,6 +11,7 @@ import type { PolygonAppearance } from "../../..";
 import { heightReference, shadowMode } from "../../common";
 import {
   EntityExt,
+  toDistanceDisplayCondition,
   toTimeInterval,
   type FeatureComponentConfig,
   type FeatureProps,
@@ -63,6 +64,10 @@ export default function Polygon({ id, isVisible, property, geometry, layer, feat
   );
   const memoFillColor = useMemo(() => (fill ? toColor(fillColor) : undefined), [fill, fillColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return !isVisible ? null : (
     <EntityExt id={id} layerId={layer?.id} featureId={feature?.id} availability={availability}>
@@ -75,6 +80,7 @@ export default function Polygon({ id, isVisible, property, geometry, layer, feat
         outlineWidth={strokeWidth}
         heightReference={heightReference(hr)}
         shadows={shadowMode(shadows)}
+        distanceDisplayCondition={distanceDisplayCondition}
       />
     </EntityExt>
   );

--- a/src/core/engines/Cesium/Feature/Polygon/index.tsx
+++ b/src/core/engines/Cesium/Feature/Polygon/index.tsx
@@ -65,8 +65,8 @@ export default function Polygon({ id, isVisible, property, geometry, layer, feat
   const memoFillColor = useMemo(() => (fill ? toColor(fillColor) : undefined), [fill, fillColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return !isVisible ? null : (

--- a/src/core/engines/Cesium/Feature/Polyline/index.tsx
+++ b/src/core/engines/Cesium/Feature/Polyline/index.tsx
@@ -10,6 +10,7 @@ import type { PolylineAppearance } from "../../..";
 import { shadowMode } from "../../common";
 import {
   EntityExt,
+  toDistanceDisplayCondition,
   toTimeInterval,
   type FeatureComponentConfig,
   type FeatureProps,
@@ -41,6 +42,10 @@ export default function Polyline({ id, isVisible, property, geometry, layer, fea
   );
   const material = useMemo(() => toColor(strokeColor), [strokeColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
+  const distanceDisplayCondition = useMemo(
+    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
+    [property?.distanceDisplayCondition],
+  );
 
   return !isVisible ? null : (
     <EntityExt id={id} layerId={layer?.id} featureId={feature?.id} availability={availability}>
@@ -50,6 +55,7 @@ export default function Polyline({ id, isVisible, property, geometry, layer, fea
         material={material}
         clampToGround={clampToGround}
         shadows={shadowMode(shadows)}
+        distanceDisplayCondition={distanceDisplayCondition}
       />
     </EntityExt>
   );

--- a/src/core/engines/Cesium/Feature/Polyline/index.tsx
+++ b/src/core/engines/Cesium/Feature/Polyline/index.tsx
@@ -43,8 +43,8 @@ export default function Polyline({ id, isVisible, property, geometry, layer, fea
   const material = useMemo(() => toColor(strokeColor), [strokeColor]);
   const availability = useMemo(() => toTimeInterval(feature?.interval), [feature?.interval]);
   const distanceDisplayCondition = useMemo(
-    () => toDistanceDisplayCondition(property?.distanceDisplayCondition),
-    [property?.distanceDisplayCondition],
+    () => toDistanceDisplayCondition(property?.near, property?.far),
+    [property?.near, property?.far],
   );
 
   return !isVisible ? null : (

--- a/src/core/engines/Cesium/Feature/utils.tsx
+++ b/src/core/engines/Cesium/Feature/utils.tsx
@@ -9,6 +9,7 @@ import {
   PropertyBag,
   TimeInterval as CesiumTimeInterval,
   TimeIntervalCollection as CesiumTimeIntervalCollection,
+  DistanceDisplayCondition as CesiumDistanceDisplayCondition,
 } from "cesium";
 import {
   ComponentProps,
@@ -20,7 +21,13 @@ import {
 } from "react";
 import { type CesiumComponentRef, Entity } from "resium";
 
-import { Data, Layer, LayerSimple, TimeInterval } from "@reearth/core/mantle";
+import {
+  Data,
+  DistanceDisplayCondition,
+  Layer,
+  LayerSimple,
+  TimeInterval,
+} from "@reearth/core/mantle";
 
 import type { ComputedFeature, ComputedLayer, FeatureComponentProps, Geometry } from "../..";
 
@@ -178,4 +185,13 @@ export const toTimeInterval = (
       stop: interval[1] ? JulianDate.fromDate(interval[1]) : Iso8601.MAXIMUM_VALUE,
     }),
   ]);
+};
+
+export const toDistanceDisplayCondition = (
+  cond: DistanceDisplayCondition | undefined,
+): CesiumDistanceDisplayCondition | undefined => {
+  if (!cond) {
+    return;
+  }
+  return new CesiumDistanceDisplayCondition(cond.near || 0.0, cond.far || Number.MAX_VALUE);
 };

--- a/src/core/engines/Cesium/Feature/utils.tsx
+++ b/src/core/engines/Cesium/Feature/utils.tsx
@@ -21,13 +21,7 @@ import {
 } from "react";
 import { type CesiumComponentRef, Entity } from "resium";
 
-import {
-  Data,
-  DistanceDisplayCondition,
-  Layer,
-  LayerSimple,
-  TimeInterval,
-} from "@reearth/core/mantle";
+import { Data, Layer, LayerSimple, TimeInterval } from "@reearth/core/mantle";
 
 import type { ComputedFeature, ComputedLayer, FeatureComponentProps, Geometry } from "../..";
 
@@ -188,10 +182,8 @@ export const toTimeInterval = (
 };
 
 export const toDistanceDisplayCondition = (
-  cond: DistanceDisplayCondition | undefined,
+  near: number | undefined,
+  far: number | undefined,
 ): CesiumDistanceDisplayCondition | undefined => {
-  if (!cond) {
-    return;
-  }
-  return new CesiumDistanceDisplayCondition(cond.near || 0.0, cond.far || Number.MAX_VALUE);
+  return new CesiumDistanceDisplayCondition(near || 0.0, far || Number.MAX_VALUE);
 };

--- a/src/core/engines/Cesium/Feature/utils.tsx
+++ b/src/core/engines/Cesium/Feature/utils.tsx
@@ -185,5 +185,7 @@ export const toDistanceDisplayCondition = (
   near: number | undefined,
   far: number | undefined,
 ): CesiumDistanceDisplayCondition | undefined => {
-  return new CesiumDistanceDisplayCondition(near || 0.0, far || Number.MAX_VALUE);
+  return typeof near === "number" || typeof far === "number"
+    ? new CesiumDistanceDisplayCondition(near ?? 0.0, far ?? Number.MAX_VALUE)
+    : undefined;
 };

--- a/src/core/mantle/types/appearance.ts
+++ b/src/core/mantle/types/appearance.ts
@@ -1,13 +1,7 @@
 import { objKeys } from "../utils";
 
 import type { ExpressionContainer } from "./expression";
-import type {
-  Camera,
-  DistanceDisplayCondition,
-  EXPERIMENTAL_clipping,
-  LatLng,
-  Typography,
-} from "./value";
+import type { Camera, EXPERIMENTAL_clipping, LatLng, Typography } from "./value";
 
 export type LayerAppearance<T> = {
   [K in keyof T]?: T[K] | ExpressionContainer;
@@ -65,7 +59,8 @@ export type MarkerAppearance = {
   labelBackgroundPaddingHorizontal?: number;
   labelBackgroundPaddingVertical?: number;
   extrude?: boolean;
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export type PolylineAppearance = {
@@ -73,7 +68,8 @@ export type PolylineAppearance = {
   strokeColor?: string;
   strokeWidth?: number;
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export type PolygonAppearance = {
@@ -85,7 +81,8 @@ export type PolygonAppearance = {
   heightReference?: "none" | "clamp" | "relative";
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   lineJoin?: CanvasLineJoin;
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export type EllipsoidAppearance = {
@@ -93,7 +90,8 @@ export type EllipsoidAppearance = {
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   radius?: number;
   fillColor?: string;
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export type ModelAppearance = {
@@ -116,7 +114,8 @@ export type ModelAppearance = {
   silhouetteColor?: string;
   bearing?: number;
   silhouetteSize?: number; // default: 1
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export type Cesium3DTilesAppearance = {
@@ -147,7 +146,8 @@ export type LegacyPhotooverlayAppearance = {
   imageShadowPositionY?: number;
   photoOverlayImage?: string;
   photoOverlayDescription?: string;
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export type ResourceAppearance = {
@@ -189,7 +189,8 @@ export type BoxAppearance = {
   activeBox?: boolean;
   activeScalePointIndex?: number; // 0 ~ 11
   activeEdgeIndex?: number; // 0 ~ 11
-  distanceDisplayCondition?: DistanceDisplayCondition;
+  near?: number;
+  far?: number;
 };
 
 export const appearanceKeyObj: { [k in keyof AppearanceTypes]: 1 } = {

--- a/src/core/mantle/types/appearance.ts
+++ b/src/core/mantle/types/appearance.ts
@@ -1,7 +1,13 @@
 import { objKeys } from "../utils";
 
 import type { ExpressionContainer } from "./expression";
-import type { Camera, EXPERIMENTAL_clipping, LatLng, Typography } from "./value";
+import type {
+  Camera,
+  DistanceDisplayCondition,
+  EXPERIMENTAL_clipping,
+  LatLng,
+  Typography,
+} from "./value";
 
 export type LayerAppearance<T> = {
   [K in keyof T]?: T[K] | ExpressionContainer;
@@ -59,6 +65,7 @@ export type MarkerAppearance = {
   labelBackgroundPaddingHorizontal?: number;
   labelBackgroundPaddingVertical?: number;
   extrude?: boolean;
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export type PolylineAppearance = {
@@ -66,6 +73,7 @@ export type PolylineAppearance = {
   strokeColor?: string;
   strokeWidth?: number;
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export type PolygonAppearance = {
@@ -77,6 +85,7 @@ export type PolygonAppearance = {
   heightReference?: "none" | "clamp" | "relative";
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   lineJoin?: CanvasLineJoin;
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export type EllipsoidAppearance = {
@@ -84,6 +93,7 @@ export type EllipsoidAppearance = {
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   radius?: number;
   fillColor?: string;
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export type ModelAppearance = {
@@ -106,6 +116,7 @@ export type ModelAppearance = {
   silhouetteColor?: string;
   bearing?: number;
   silhouetteSize?: number; // default: 1
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export type Cesium3DTilesAppearance = {
@@ -136,6 +147,7 @@ export type LegacyPhotooverlayAppearance = {
   imageShadowPositionY?: number;
   photoOverlayImage?: string;
   photoOverlayDescription?: string;
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export type ResourceAppearance = {
@@ -177,6 +189,7 @@ export type BoxAppearance = {
   activeBox?: boolean;
   activeScalePointIndex?: number; // 0 ~ 11
   activeEdgeIndex?: number; // 0 ~ 11
+  distanceDisplayCondition?: DistanceDisplayCondition;
 };
 
 export const appearanceKeyObj: { [k in keyof AppearanceTypes]: 1 } = {

--- a/src/core/mantle/types/value.ts
+++ b/src/core/mantle/types/value.ts
@@ -30,6 +30,11 @@ export type Typography = {
   underline?: boolean;
 };
 
+export type DistanceDisplayCondition = {
+  near: number; // meter
+  far: number; // meter
+};
+
 export type Coordinates = LatLngHeight[];
 
 export type Polygon = LatLngHeight[][];

--- a/src/core/mantle/types/value.ts
+++ b/src/core/mantle/types/value.ts
@@ -30,11 +30,6 @@ export type Typography = {
   underline?: boolean;
 };
 
-export type DistanceDisplayCondition = {
-  near: number; // meter
-  far: number; // meter
-};
-
 export type Coordinates = LatLngHeight[];
 
 export type Polygon = LatLngHeight[][];


### PR DESCRIPTION
# Overview

## What I've done

```
reearth.layers.add({
  type: "simple",
  data: {
    type: "csv",
    // url: "xxx.csv",
    value: `id,lat,lng,height,name\n1,0,0,0,hoge`,
    csv: {
	    idColumn: "id",
	    latColumn: "lat",
	    lngColumn: "lng",
	    heightColumn: "height",
	    noHeader: false,
    }
  },
  marker: {
    imageColor: {
      expression: "${name} === 'hoge' ? color('blue') : color('red')",
    },
    distanceDisplayCondition: {
      near: 100000,
    }
  }
});
```

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
