### PR TITLE
fix: add properties in vehicle point for gtfs

### DIFF
--- a/src/core/mantle/data/gtfs.ts
+++ b/src/core/mantle/data/gtfs.ts
@@ -54,7 +54,7 @@ export function processGTFS(gtfs?: GTFS, _range?: DataRange): Feature[] | void {
             f.properties.position?.latitude || 0,
           ],
         },
-        properties: {},
+        properties: f.properties,
       };
     });
 }


### PR DESCRIPTION
# Overview
This PR adds vehicle property to the GeoJSON Point obtained for the GTFS feed.
