### PR TITLE
fix: revert appearance to initial value when appearance is undefined on reearth/core

### DIFF
--- a/src/core/Map/Layers/hooks.test.ts
+++ b/src/core/Map/Layers/hooks.test.ts
@@ -465,7 +465,7 @@ test("override", () => {
   if (l4.type !== "simple") throw new Error("invalid layer type");
   expect(l4.title).toBe("Y!!");
   expect(l4.data?.value).toBe(dataValue2);
-  expect(l4.marker).toEqual({ pointSize: 10, pointColor: "red" });
+  expect(l4.marker).toEqual({});
   expect(l2.tags).toEqual([{ id: "t2", label: "t2" }]);
 
   result.current.ref.current?.override("y", { marker: undefined });
@@ -541,7 +541,7 @@ test("override property for compat", () => {
   const l2 = result.current.flattenedLayers[1];
   if (l2.type !== "simple") throw new Error("invalid layer type");
   expect(l2.data?.value).toBe(dataValue);
-  expect(l2.marker).toEqual({ pointSize: 10, pointColor: "red" });
+  expect(l2.marker).toEqual({});
 
   result.current.ref.current?.override("y");
   rerender();
@@ -549,7 +549,7 @@ test("override property for compat", () => {
   if (l3.type !== "simple") throw new Error("invalid layer type");
   expect(l3.title).toBe("Y");
   expect(l3.data?.value).toBe(dataValue);
-  expect(l3.marker).toEqual({ pointSize: 10, pointColor: "red" });
+  expect(l3.marker).toEqual({});
   expect(l3.tags).toBeUndefined();
 });
 

--- a/src/core/Map/Layers/hooks.ts
+++ b/src/core/Map/Layers/hooks.ts
@@ -1,5 +1,5 @@
 import { atom, useAtomValue } from "jotai";
-import { merge, omit, isEqual } from "lodash-es";
+import { omit, isEqual } from "lodash-es";
 import {
   ForwardedRef,
   useCallback,
@@ -134,8 +134,7 @@ export default function useHooks({
 
       // prevents unnecessary copying of data value
       const dataValue = ol.data?.value ?? (l.type === "simple" ? l.data?.value : undefined);
-      const res = merge(
-        {},
+      const res = deepAssign(
         {
           ...l,
           ...(l.type === "simple" && l.data ? { data: omit(l.data, "value") } : {}),

--- a/src/core/Map/Layers/utils.test.ts
+++ b/src/core/Map/Layers/utils.test.ts
@@ -12,11 +12,9 @@ test("deepAssign", () => {
 
   expect(
     deepAssign({ marker: { color: "red", size: 100 } }, { marker: { color: undefined } }),
-  ).toEqual({ marker: { color: "red", size: 100 } });
+  ).toEqual({ marker: { size: 100 } });
 
-  expect(deepAssign({ marker: { color: "red", size: 100 } }, { marker: undefined })).toEqual({
-    marker: { color: "red", size: 100 },
-  });
+  expect(deepAssign({ marker: { color: "red", size: 100 } }, { marker: undefined })).toEqual({});
 
   expect(
     deepAssign(
@@ -24,7 +22,6 @@ test("deepAssign", () => {
       { marker: undefined },
     ),
   ).toEqual({
-    marker: { color: "red", size: 100 },
     test: { value: ["abc"] },
   });
 

--- a/src/core/Map/Layers/utils.ts
+++ b/src/core/Map/Layers/utils.ts
@@ -5,6 +5,10 @@ export const deepAssign = <O extends Record<string, any>>(obj: O, src: O) => {
     Object.entries({ ...src, ...obj })
       .map(([k, v]): [string, any] | undefined => {
         const srcV: unknown = src[k];
+        if (Object.hasOwn(src, k) && (srcV === undefined || srcV === null)) {
+          return undefined;
+        }
+
         if (srcV === undefined) {
           return [k, v];
         }


### PR DESCRIPTION
# Overview

## What I've done

```js
const id = reearth.layers.add({
  type: "simple",
  data: { 
    type: "geojson",
    value: { // GeoJSON
      "type": "Feature",
      "geometry": {
        "coordinates": [
          -15.209829106984472,
          20.323569554406248,
          10000
        ],
        "type": "Point"
      }
    }
  },
});
reearth.layers.override(id, { marker: {} });
reearth.layers.override(id, { marker: undefined }); // appearance will be removed
```

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
