### PR TITLE
fix: copy lazy layer on plugin on reearth/core

### DIFF
--- a/src/core/Crust/Plugins/api.ts
+++ b/src/core/Crust/Plugins/api.ts
@@ -1,5 +1,14 @@
 import type { Tag } from "@reearth/core/mantle/compat";
-import type { Events, Layer, LayerSelectionReason, LayersRef, NaiveLayer } from "@reearth/core/Map";
+import {
+  copyLazyLayer,
+  Events,
+  Layer,
+  LayerSelectionReason,
+  LayersRef,
+  NaiveLayer,
+  LazyLayer,
+  copyLazyLayers,
+} from "@reearth/core/Map";
 import { merge } from "@reearth/util/object";
 
 import type { Block } from "../Infobox";
@@ -475,7 +484,7 @@ export function commonReearth({
         return !!layers()?.isLayer;
       },
       get layers() {
-        return layers()?.layers() ?? [];
+        return copyLazyLayers(layers()?.layers()) ?? [];
       },
       get tags() {
         return tags();
@@ -496,22 +505,29 @@ export function commonReearth({
         return selectedFeature();
       },
       get findById() {
-        return layers()?.findById;
+        return (id: string) => copyLazyLayer(layers()?.findById(id));
       },
       get findByIds() {
-        return layers()?.findByIds;
+        return (...args: string[]) =>
+          copyLazyLayers(
+            layers()
+              ?.findByIds(...args)
+              ?.filter((l): l is LazyLayer => !!l),
+          );
       },
       get findByTags() {
-        return layers()?.findByTags;
+        return (...args: string[]) => copyLazyLayers(layers()?.findByTags(...args));
       },
       get findByTagLabels() {
-        return layers()?.findByTagLabels;
+        return (...args: string[]) => copyLazyLayers(layers()?.findByTagLabels(...args));
       },
       get find() {
-        return layers()?.find;
+        return (cb: (layer: LazyLayer, index: number, parents: LazyLayer[]) => boolean) =>
+          copyLazyLayer(layers()?.find(cb));
       },
       get findAll() {
-        return layers()?.findAll;
+        return (cb: (layer: LazyLayer, index: number, parents: LazyLayer[]) => boolean) =>
+          copyLazyLayers(layers()?.findAll(cb));
       },
       get override() {
         return layers()?.override;

--- a/src/core/Map/Layers/index.tsx
+++ b/src/core/Map/Layers/index.tsx
@@ -27,6 +27,7 @@ export type {
   ClusterProperty,
   Cluster,
 } from "../ClusteredLayers";
+export { copyLazyLayers, copyLazyLayer } from "./utils";
 
 export type Props = Omit<ClusteredLayerProps, "atomMap" | "isHidden"> & {
   hiddenLayers?: string[];

--- a/src/core/Map/Layers/utils.ts
+++ b/src/core/Map/Layers/utils.ts
@@ -1,5 +1,8 @@
 import { isArray, isObject } from "lodash-es";
 
+import { LazyLayer } from "./hooks";
+import { layerKeys, computedLayerKeys } from "./keys";
+
 export const deepAssign = <O extends Record<string, any>>(obj: O, src: O) => {
   return Object.fromEntries(
     Object.entries({ ...src, ...obj })
@@ -34,4 +37,24 @@ export const deepAssign = <O extends Record<string, any>>(obj: O, src: O) => {
       })
       .filter((v): v is [string, any] => !!v),
   ) as O;
+};
+
+export const copyLazyLayers = (layers: LazyLayer[] | undefined) => {
+  return layers?.map(l => {
+    return copyLazyLayer(l);
+  });
+};
+
+export const copyLazyLayer = (l: LazyLayer | undefined) => {
+  return layerKeys.reduce((res, key) => {
+    if (key === "computed") {
+      res[key] = computedLayerKeys.reduce((computedRes, computedKey) => {
+        computedRes[computedKey] = l?.[key as keyof LazyLayer][computedKey];
+        return computedRes;
+      }, {} as Record<string, any>);
+      return res;
+    }
+    res[key] = l?.[key as keyof LazyLayer];
+    return res;
+  }, {} as Record<string, any>) as LazyLayer;
 };

--- a/src/core/Map/index.tsx
+++ b/src/core/Map/index.tsx
@@ -6,6 +6,7 @@ import type { Engine, EngineProps } from "./types";
 
 export * from "./types";
 export { useGet, type WrappedRef, type Undefinable, useOverriddenProperty } from "./utils";
+export { copyLazyLayers, copyLazyLayer } from "./Layers";
 
 export type {
   NaiveLayer,


### PR DESCRIPTION
# Overview

We can not refer `reearth.layers.layers`'s properties. Because `layers` are computed asynchronously, so we are wrapping layers with `Object.defineProperties` to refer property lazily.
But quickjs can not refer these property. For example, when we run `Object.keys(lazyLayers)`  then the result returns only `id` property.
So I fixed to copy these value when layers are referred on plugin.

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
