### PR TITLE
fix: parse hyphen as reserved word in property key on reearth/core

### DIFF
--- a/src/core/mantle/evaluator/simple/expression/variableReplacer.test.ts
+++ b/src/core/mantle/evaluator/simple/expression/variableReplacer.test.ts
@@ -46,4 +46,9 @@ describe("replaceVariables", () => {
       `czm_va$reearth_opened_square_bracket_$ria$reearth_closed_square_bracket_$ble + czm_variable[0] + czm_variable['key'] + czm_variable["key"] + czm_variable[variable] + czm_variable[variable].nested + czm_variable[variable]['nested']`,
     );
   });
+
+  test("should replace reserved hyphen", () => {
+    const [result, _] = replaceVariables("${vari-able}");
+    expect(result).toBe(`czm_vari$reearth_hyphen_$able`);
+  });
 });

--- a/src/core/mantle/evaluator/simple/expression/variableReplacer.ts
+++ b/src/core/mantle/evaluator/simple/expression/variableReplacer.ts
@@ -105,10 +105,12 @@ const RESERVED_WORDS: Record<string, string> = {
   "}": makeReservedWord("closed_curly_bracket"),
   "(": makeReservedWord("opened_parentheses"),
   ")": makeReservedWord("closed_parentheses"),
+  "-": makeReservedWord("hyphen"),
 };
 
 const replaceReservedWord = (word: string) => {
-  return word.replaceAll(
+  const wordFiltered = word.replace(/-/g, RESERVED_WORDS["-"]);
+  return wordFiltered.replaceAll(
     /(.*)(\[|\{|\()(.*)(\]|\}|\))(?!\.|\[)(.+)/g,
     (_match, prefix, openedBracket, inner, closedBracket, suffix) => {
       return `${prefix}${RESERVED_WORDS[openedBracket]}${inner}${RESERVED_WORDS[closedBracket]}${suffix}`;


### PR DESCRIPTION
# Overview
This PR fixes an issue when properties key contains `hyphen` in them.