### PR TITLE
fix: abort fetching on data atom on reearth/core

### DIFF
--- a/src/core/Crust/Widgets/Widget/Timeline/hooks.ts
+++ b/src/core/Crust/Widgets/Widget/Timeline/hooks.ts
@@ -190,9 +190,11 @@ export const useTimeline = ({
   const overriddenCurrentTime = overriddenClock?.current?.getTime();
   useEffect(() => {
     if (overriddenCurrentTime) {
-      setCurrentTime(Math.max(Math.min(range.end, overriddenCurrentTime), range.start));
+      const t = Math.max(Math.min(range.end, overriddenCurrentTime), range.start);
+      setCurrentTime(t);
+      onTimeChange?.(new Date(t));
     }
-  }, [overriddenCurrentTime, range]);
+  }, [overriddenCurrentTime, range, onTimeChange]);
 
   useEffect(() => {
     if (isMobile) {

--- a/src/core/mantle/data/csv.ts
+++ b/src/core/mantle/data/csv.ts
@@ -2,9 +2,13 @@ import type { Feature as GeoJSONFeature, Point } from "geojson";
 
 import type { Data, DataRange, Feature } from "../types";
 
-import { f, generateRandomString } from "./utils";
+import { f, FetchOptions, generateRandomString } from "./utils";
 
-export async function fetchCSV(data: Data, range?: DataRange): Promise<Feature[] | void> {
+export async function fetchCSV(
+  data: Data,
+  range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
   if (!data.url) {
     const value = data.value;
     if (typeof value !== "string") {
@@ -13,7 +17,7 @@ export async function fetchCSV(data: Data, range?: DataRange): Promise<Feature[]
     }
     return await parseCSV(value, data.csv, range);
   }
-  const csvText = await (await f(data.url)).text();
+  const csvText = await (await f(data.url, options)).text();
   return await parseCSV(csvText, data.csv, range);
 }
 

--- a/src/core/mantle/data/geojson.ts
+++ b/src/core/mantle/data/geojson.ts
@@ -2,10 +2,14 @@ import type { GeoJSON } from "geojson";
 
 import type { Data, DataRange, Feature } from "../types";
 
-import { f, generateRandomString } from "./utils";
+import { f, FetchOptions, generateRandomString } from "./utils";
 
-export async function fetchGeoJSON(data: Data, range?: DataRange): Promise<Feature[] | void> {
-  const d = data.url ? await (await f(data.url)).json() : data.value;
+export async function fetchGeoJSON(
+  data: Data,
+  range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
+  const d = data.url ? await (await f(data.url, options)).json() : data.value;
   return processGeoJSON(d, range);
 }
 

--- a/src/core/mantle/data/georss.ts
+++ b/src/core/mantle/data/georss.ts
@@ -4,10 +4,14 @@ import type { Data, DataRange, Feature, Geometry } from "../types";
 
 import { getGeometryOfItem } from "./gml";
 import type { Shape } from "./gml";
-import { f, convertToCoordinates } from "./utils";
+import { f, convertToCoordinates, FetchOptions } from "./utils";
 
-export async function fetchGeoRSS(data: Data, _range?: DataRange): Promise<Feature[] | void> {
-  const xmlDataStr = data.url ? await (await f(data.url)).text() : data.value;
+export async function fetchGeoRSS(
+  data: Data,
+  _range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
+  const xmlDataStr = data.url ? await (await f(data.url, options)).text() : data.value;
   return handler(xmlDataStr);
 }
 

--- a/src/core/mantle/data/gml.ts
+++ b/src/core/mantle/data/gml.ts
@@ -2,10 +2,14 @@ import { XMLParser, X2jOptionsOptional } from "fast-xml-parser";
 
 import type { Data, DataRange, Feature, Geometry } from "../types";
 
-import { f, convertToCoordinates } from "./utils";
+import { f, convertToCoordinates, FetchOptions } from "./utils";
 
-export async function fetchGMLData(data: Data, _range?: DataRange): Promise<Feature[] | void> {
-  const xmlDataStr = data.url ? await (await f(data.url)).text() : data.value;
+export async function fetchGMLData(
+  data: Data,
+  _range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
+  const xmlDataStr = data.url ? await (await f(data.url, options)).text() : data.value;
   return handler(xmlDataStr);
 }
 

--- a/src/core/mantle/data/gpx.ts
+++ b/src/core/mantle/data/gpx.ts
@@ -3,10 +3,14 @@ import type { LineString, Position, GeoJsonProperties } from "geojson";
 
 import type { Data, DataRange, Feature } from "../types";
 
-import { f, generateRandomString } from "./utils";
+import { f, FetchOptions, generateRandomString } from "./utils";
 
-export async function fetchGPXfile(data: Data, _range?: DataRange): Promise<Feature[] | void> {
-  const xmlDataStr = data.url ? await (await f(data.url)).text() : data.value;
+export async function fetchGPXfile(
+  data: Data,
+  _range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
+  const xmlDataStr = data.url ? await (await f(data.url, options)).text() : data.value;
   return handler(xmlDataStr);
 }
 

--- a/src/core/mantle/data/gtfs.ts
+++ b/src/core/mantle/data/gtfs.ts
@@ -3,17 +3,21 @@ import Pbf from "pbf";
 import type { Data, DataRange, Feature } from "../types";
 
 import { Trips, Trip, GTFS, GTFSReader } from "./gtfsReader";
-import { f } from "./utils";
+import { f, FetchOptions } from "./utils";
 
 let gtfs: GTFS = {};
 let current: Trips = {};
 let previous: Trips = {};
 let tripsData: Trips = {};
 
-export async function fetchGTFS(data: Data, range?: DataRange): Promise<Feature[] | void> {
+export async function fetchGTFS(
+  data: Data,
+  range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
   const fetchData = async () => {
     try {
-      const arrayBuffer = data.url ? await (await f(data.url)).arrayBuffer() : data.value;
+      const arrayBuffer = data.url ? await (await f(data.url, options)).arrayBuffer() : data.value;
       const pbfBuffer = new Pbf(new Uint8Array(arrayBuffer));
       gtfs = new GTFSReader().read(pbfBuffer);
     } catch (err) {

--- a/src/core/mantle/data/index.ts
+++ b/src/core/mantle/data/index.ts
@@ -9,8 +9,13 @@ import { fetchGMLData } from "./gml";
 import { fetchGPXfile } from "./gpx";
 import { fetchGTFS } from "./gtfs";
 import { fetchShapefile } from "./shapefile";
+import { FetchOptions } from "./utils";
 
-export type DataFetcher = (data: Data, range?: DataRange) => Promise<Feature[] | void>;
+export type DataFetcher = (
+  data: Data,
+  range?: DataRange,
+  options?: FetchOptions,
+) => Promise<Feature[] | void>;
 
 const registry: Record<string, DataFetcher> = {
   geojson: fetchGeoJSON,
@@ -22,7 +27,11 @@ const registry: Record<string, DataFetcher> = {
   gml: fetchGMLData,
 };
 
-export async function fetchData(data: Data, range?: DataRange): Promise<Feature[] | void> {
+export async function fetchData(
+  data: Data,
+  range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
   const ext = !data.type || (data.type as string) === "auto" ? getExtname(data.url) : undefined;
-  return registry[ext || data.type]?.(data, range);
+  return registry[ext || data.type]?.(data, range, options);
 }

--- a/src/core/mantle/data/shapefile.ts
+++ b/src/core/mantle/data/shapefile.ts
@@ -4,10 +4,14 @@ import JSZip from "jszip";
 import type { Data, DataRange, Feature } from "../types";
 
 import { processGeoJSON } from "./geojson";
-import { f } from "./utils";
+import { f, FetchOptions } from "./utils";
 
-export async function fetchShapefile(data: Data, range?: DataRange): Promise<Feature[] | void> {
-  const arrayBuffer = data.url ? await (await f(data.url)).arrayBuffer() : data.value;
+export async function fetchShapefile(
+  data: Data,
+  range?: DataRange,
+  options?: FetchOptions,
+): Promise<Feature[] | void> {
+  const arrayBuffer = data.url ? await (await f(data.url, options)).arrayBuffer() : data.value;
   const zip = await JSZip.loadAsync(new Uint8Array(arrayBuffer));
 
   let shpFileArrayBuffer: ArrayBuffer | undefined;

--- a/src/core/mantle/data/utils.ts
+++ b/src/core/mantle/data/utils.ts
@@ -1,7 +1,11 @@
 export { default as generateRandomString } from "@reearth/util/generate-random-string";
 
-export async function f(url: string): Promise<Response> {
-  const res = await fetch(url);
+export type FetchOptions = {
+  signal?: AbortSignal;
+};
+
+export async function f(url: string, options?: FetchOptions): Promise<Response> {
+  const res = await fetch(url, options);
   if (res.status !== 200) {
     throw new Error(`fetched ${url} but status code was ${res.status}`);
   }


### PR DESCRIPTION
# Overview

When we override layer on adding layer, overriding process is skipped if data atom is fetching.
So I fixed to abort only fetching process, not skip entire overriding process.

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
