### PR TITLE
feat: add defaultContent property for infobox in plugin API on reearth/core

### DIFF
--- a/src/core/Crust/Infobox/types.ts
+++ b/src/core/Crust/Infobox/types.ts
@@ -20,6 +20,7 @@ export type InfoboxProperty = {
   outlineColor?: string;
   outlineWidth?: number;
   useMask?: boolean;
+  defaultContent?: "description" | "attributes";
 };
 
 export type Block<P = any> = {

--- a/src/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/src/core/engines/Cesium/Feature/Resource/utils.ts
@@ -1,4 +1,11 @@
-import { JulianDate, Entity, Cartesian3, PolygonHierarchy } from "cesium";
+import {
+  JulianDate,
+  Entity,
+  Cartesian3,
+  PolygonHierarchy,
+  PointGraphics,
+  BillboardGraphics,
+} from "cesium";
 
 import { AppearanceTypes, ComputedFeature, ComputedLayer, Feature } from "@reearth/core/mantle";
 import { EvalFeature } from "@reearth/core/Map";
@@ -53,7 +60,7 @@ export function attachProperties<
   const [appearanceName, propertyName] = namePair;
   const property = entity[propertyName] ?? {};
   if (!entity[propertyName]) {
-    entity[propertyName] = {} as any;
+    return;
   }
 
   const tag = getTag(entity);
@@ -141,6 +148,12 @@ export const attachStyle = (
     }
     const simpleLayer = extractSimpleLayer(layer);
     if (point) {
+      const isPointStyle = simpleLayer?.marker?.style === "point";
+      if (isPointStyle && !entity.point) {
+        entity.point = new PointGraphics();
+        entity.billboard = undefined;
+      }
+
       attachProperties(entity, computedFeature, ["marker", "point"], {
         show: {
           name: "show",
@@ -173,6 +186,12 @@ export const attachStyle = (
     }
 
     if (billboard) {
+      const isImageStyle = simpleLayer?.marker?.style === "image";
+      if (isImageStyle && !entity.billboard) {
+        entity.billboard = new BillboardGraphics();
+        entity.point = undefined;
+      }
+
       attachProperties(entity, computedFeature, ["marker", "billboard"], {
         show: {
           name: "show",

--- a/src/core/engines/Cesium/utils.ts
+++ b/src/core/engines/Cesium/utils.ts
@@ -9,7 +9,11 @@ import {
   Cesium3DTileset,
   Cesium3DTileContent,
   Cesium3DTileFeature,
+  JulianDate,
 } from "cesium";
+
+import { InfoboxProperty } from "@reearth/core/Crust/Infobox";
+import { DefaultInfobox } from "@reearth/core/Map";
 
 import { getTag } from "./Feature";
 
@@ -136,4 +140,33 @@ export function findEntity(
   }
 
   return;
+}
+
+export const getEntityContent = (
+  entity: Entity,
+  time: JulianDate,
+  defaultContent: InfoboxProperty["defaultContent"],
+): DefaultInfobox["content"] => {
+  const content: Record<
+    Exclude<InfoboxProperty["defaultContent"], undefined>,
+    DefaultInfobox["content"]
+  > = {
+    description: {
+      type: "html",
+      value: entity.description?.getValue(time),
+    },
+    attributes: {
+      type: "table",
+      value: entity.properties ? entityProperties(entity.properties.getValue(time)) : [],
+    },
+  };
+
+  return defaultContent ? content[defaultContent] : content.description ?? content.attributes;
+};
+
+function entityProperties(properties: Record<string, any>): { key: string; value: any }[] {
+  return Object.entries(properties).reduce<{ key: string; value: [string, string] }[]>(
+    (a, [key, value]) => [...a, { key, value }],
+    [],
+  );
 }

--- a/src/core/mantle/compat/types.ts
+++ b/src/core/mantle/compat/types.ts
@@ -41,6 +41,7 @@ export type InfoboxProperty = {
     outlineColor?: string;
     outlineWidth?: number;
     useMask?: boolean;
+    defaultContent?: "description" | "attributes";
   };
 };
 


### PR DESCRIPTION
# Overview

sample code

```js
reearth.layers.add({
  type: "simple",
  data: {
    type: "czml",
    url: "{CZML URL}",
  },
  resource: {},
  infobox: {
    property: {
      default: {
        defaultContent: "attributes" // or "description"
      }
    }
  }
});

```

## What I've done

## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
