### PR TITLE
fix: use overriddenLayers to get infobox on reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -107,9 +107,11 @@ export default function Resource({ isVisible, property, layer, onComputedFeature
         }
         return;
       }
-      viewer.clock.currentTime = ds.clock.currentTime;
-      viewer.clock.startTime = ds.clock.startTime;
-      viewer.clock.stopTime = ds.clock.stopTime;
+      if (ds.clock) {
+        viewer.clock.currentTime = ds.clock.currentTime;
+        viewer.clock.startTime = ds.clock.startTime;
+        viewer.clock.stopTime = ds.clock.stopTime;
+      }
     },
     [updateClock, viewer?.clock],
   );

--- a/src/core/engines/Cesium/hooks.ts
+++ b/src/core/engines/Cesium/hooks.ts
@@ -239,6 +239,10 @@ export default ({
     }
 
     if (entity) {
+      const layer = tag?.layerId
+        ? layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
+          layersRef?.current?.findById(tag.layerId)
+        : undefined;
       // Sometimes only featureId is specified, so we need to sync entity tag.
       onLayerSelect?.(
         tag?.layerId,
@@ -250,10 +254,7 @@ export default ({
                 content: getEntityContent(
                   entity,
                   cesium.current?.cesiumElement?.clock.currentTime ?? new JulianDate(),
-                  tag?.layerId
-                    ? layersRef?.current?.findById(tag.layerId)?.infobox?.property?.default
-                        ?.defaultContent
-                    : undefined,
+                  tag?.layerId ? layer?.infobox?.property?.default?.defaultContent : undefined,
                 ),
               },
             }
@@ -328,6 +329,10 @@ export default ({
 
       if (target && "id" in target && target.id instanceof Entity && isSelectable(target.id)) {
         const tag = getTag(target.id);
+        const layer = tag?.layerId
+          ? layersRef?.current?.overriddenLayers().find(l => l.id === tag.layerId) ??
+            layersRef?.current?.findById(tag.layerId)
+          : undefined;
         onLayerSelect?.(
           tag?.layerId,
           tag?.featureId,
@@ -338,10 +343,7 @@ export default ({
                   content: getEntityContent(
                     target.id,
                     viewer.clock.currentTime ?? new JulianDate(),
-                    tag?.layerId
-                      ? layersRef?.current?.findById(tag.layerId)?.infobox?.property?.default
-                          ?.defaultContent
-                      : undefined,
+                    tag?.layerId ? layer?.infobox?.property?.default?.defaultContent : undefined,
                   ),
                 },
               }
@@ -386,7 +388,7 @@ export default ({
 
       onLayerSelect?.();
     },
-    [onLayerSelect, mouseEventHandles, layersRef, selectedLayerId?.layerId],
+    [onLayerSelect, mouseEventHandles, layersRef],
   );
 
   // E2E test


### PR DESCRIPTION
# Overview

It should work.

```
const id = reearth.layers.add({
  type: "simple",
  data: {
    type: "czml",
    url: "https://assets.cms.plateau.reearth.io/assets/b0/9701c5-79cc-437a-b807-1593ffa2a034/28225_asago-shi_landmark.czml",
  },
  resource: {},
  infobox: {
    property: {
      default: {
        defaultContent: "attributes" // or "description"
      }
    }
  }
});


reearth.layers.override(id, { infobox: {
    property: {
      default: {
        defaultContent: "attributes"
      }
    }
  }});
```

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
