### PR TITLE
perf: use private modifier on evaluator on reearth/core

### DIFF
--- a/src/core/mantle/evaluator/simple/expression/expression.ts
+++ b/src/core/mantle/evaluator/simple/expression/expression.ts
@@ -16,23 +16,23 @@ export type JPLiteral = {
 export const EXPRESSION_CACHES = new Map<string, Node | Error>();
 
 export class Expression {
-  #expression: string;
-  #runtimeAst: Node | Error;
-  #feature?: Feature;
+  private _expression: string;
+  private _runtimeAst: Node | Error;
+  private _feature?: Feature;
 
   constructor(expression: string, feature?: Feature, defines?: any) {
-    this.#expression = expression;
-    this.#feature = feature;
+    this._expression = expression;
+    this._feature = feature;
     let literalJP: JPLiteral[] = [];
     expression = replaceDefines(expression, defines);
     [expression, literalJP] = replaceVariables(
       removeBackslashes(expression),
-      this.#feature?.properties,
+      this._feature?.properties,
     );
 
     const cachedAST = EXPRESSION_CACHES.get(expression);
     if (cachedAST) {
-      this.#runtimeAst = cachedAST;
+      this._runtimeAst = cachedAST;
     } else {
       if (literalJP.length !== 0) {
         for (const elem of literalJP) {
@@ -51,13 +51,13 @@ export class Expression {
         throw new Error(`failed to generate ast: ${e}`);
       }
 
-      this.#runtimeAst = createRuntimeAst(this, ast);
-      EXPRESSION_CACHES.set(expression, this.#runtimeAst);
+      this._runtimeAst = createRuntimeAst(this, ast);
+      EXPRESSION_CACHES.set(expression, this._runtimeAst);
     }
   }
 
   evaluate() {
-    const value = (this.#runtimeAst as Node).evaluate(this.#feature);
+    const value = (this._runtimeAst as Node).evaluate(this._feature);
     return value;
   }
 }


### PR DESCRIPTION
# Overview

I improved performance of 3dtiles.

The cause of problem is, TypeScript transpiles class private field(eg `#name`) by using global `WeakMap` like the following.

In the following code, WeakMap is defined on global. So this code store `feature` with each instance to same WeakMap. 
So this WeakMap will consume very large memory.

So I fixed to use `private` modifier. This modifier is removed in build time.

```js
var ts = (AA,eA,tA)=>{
    if (eA.has(AA))
        throw TypeError("Cannot add the same private member more than once");
    eA instanceof WeakSet ? eA.add(AA) : eA.set(AA, tA)
}

var fQ, kC, KC;
class Expression {
    constructor(eA, tA, rA) {
        ts(this, fQ, void 0);
        ts(this, kC, void 0);
        ts(this, KC, void 0);

        // Doing something
    }

    // Doing something
}
fQ = new WeakMap,
kC = new WeakMap,
KC = new WeakMap;
```

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
