### PR TITLE
fix: deleting feature process on reearth/core

### DIFF
--- a/src/core/Map/Layer/index.tsx
+++ b/src/core/Map/Layer/index.tsx
@@ -32,6 +32,7 @@ export type FeatureComponentProps = {
   onFeatureFetch?: (features: Feature[]) => void;
   onComputedFeatureFetch?: (feature: Feature[], computed: ComputedFeature[]) => void;
   onFeatureDelete?: (features: string[]) => void;
+  onComputedFeatureDelete?: (features: string[]) => void;
   evalFeature: EvalFeature;
 } & CommonProps;
 
@@ -57,6 +58,7 @@ export default function LayerComponent({
   const {
     computedLayer,
     handleFeatureDelete,
+    handleComputedFeatureDelete,
     handleFeatureFetch,
     handleComputedFeatureFetch,
     handleFeatureRequest,
@@ -74,6 +76,7 @@ export default function LayerComponent({
     <Feature
       layer={computedLayer}
       onFeatureDelete={handleFeatureDelete}
+      onComputedFeatureDelete={handleComputedFeatureDelete}
       onFeatureFetch={handleFeatureFetch}
       onComputedFeatureFetch={handleComputedFeatureFetch}
       onFeatureRequest={handleFeatureRequest}

--- a/src/core/Map/Layers/index.test.tsx
+++ b/src/core/Map/Layers/index.test.tsx
@@ -29,6 +29,7 @@ test("simple", () => {
     onFeatureDelete: expect.any(Function),
     onFeatureFetch: expect.any(Function),
     onComputedFeatureFetch: expect.any(Function),
+    onComputedFeatureDelete: expect.any(Function),
     onFeatureRequest: expect.any(Function),
     evalFeature: expect.any(Function),
   });
@@ -45,6 +46,7 @@ test("simple", () => {
     onFeatureDelete: expect.any(Function),
     onFeatureFetch: expect.any(Function),
     onComputedFeatureFetch: expect.any(Function),
+    onComputedFeatureDelete: expect.any(Function),
     onFeatureRequest: expect.any(Function),
     evalFeature: expect.any(Function),
   });

--- a/src/core/engines/Cesium/Feature/Raster/hooks.ts
+++ b/src/core/engines/Cesium/Feature/Raster/hooks.ts
@@ -6,13 +6,12 @@ import {
   WebMapServiceImageryProvider,
 } from "cesium";
 import { MVTImageryProvider } from "cesium-mvt-imagery-provider";
-import md5 from "js-md5";
 import { isEqual, pick } from "lodash-es";
 import { useEffect, useMemo, useRef } from "react";
 import { useCesium } from "resium";
 
 import type { ComputedFeature, ComputedLayer, Feature, PolygonAppearance } from "../../..";
-import { extractSimpleLayer, extractSimpleLayerData } from "../utils";
+import { extractSimpleLayer, extractSimpleLayerData, generateIDWithMD5 } from "../utils";
 
 import { Props } from "./types";
 
@@ -77,10 +76,7 @@ const idFromGeometry = (
     ":",
   );
 
-  const hash = md5.create();
-  hash.update(id);
-
-  return hash.hex();
+  return generateIDWithMD5(id);
 };
 
 const makeFeatureFromPolygon = (
@@ -111,10 +107,7 @@ export const useMVT = ({
   property,
   layer,
   evalFeature,
-}: Pick<
-  Props,
-  "isVisible" | "property" | "layer" | "onComputedFeatureFetch" | "evalFeature" | "onFeatureDelete"
->) => {
+}: Pick<Props, "isVisible" | "property" | "layer" | "evalFeature">) => {
   const { show = true, minimumLevel, maximumLevel, credit } = property ?? {};
   const { type, url, layers } = useData(layer);
 

--- a/src/core/engines/Cesium/Feature/Raster/index.tsx
+++ b/src/core/engines/Cesium/Feature/Raster/index.tsx
@@ -6,16 +6,9 @@ import { extractSimpleLayer, extractSimpleLayerData, type FeatureComponentConfig
 import { useMVT, useWMS } from "./hooks";
 import type { Props } from "./types";
 
-function Raster({
-  isVisible,
-  layer,
-  property,
-  onComputedFeatureFetch,
-  evalFeature,
-  onFeatureDelete,
-}: Props) {
+function Raster({ isVisible, layer, property, evalFeature }: Props) {
   useWMS({ isVisible, layer, property });
-  useMVT({ isVisible, layer, property, evalFeature, onComputedFeatureFetch, onFeatureDelete });
+  useMVT({ isVisible, layer, property, evalFeature });
 
   return null;
 }

--- a/src/core/engines/Cesium/Feature/Tileset/index.tsx
+++ b/src/core/engines/Cesium/Feature/Tileset/index.tsx
@@ -22,7 +22,7 @@ function Tileset({
   meta,
   evalFeature,
   onComputedFeatureFetch,
-  onFeatureDelete,
+  onComputedFeatureDelete,
   ...props
 }: Props): JSX.Element | null {
   const { shadows, colorBlendMode } = property ?? {};
@@ -37,7 +37,7 @@ function Tileset({
     meta,
     evalFeature,
     onComputedFeatureFetch,
-    onFeatureDelete,
+    onComputedFeatureDelete,
   });
   const boxProperty = useMemo(
     () => ({
@@ -70,7 +70,7 @@ function Tileset({
           isVisible={builtinBoxProps.visible}
           evalFeature={evalFeature}
           onComputedFeatureFetch={onComputedFeatureFetch}
-          onFeatureDelete={onFeatureDelete}
+          onComputedFeatureDelete={onComputedFeatureDelete}
           onLayerEdit={builtinBoxProps.handleLayerEdit}
         />
       )}

--- a/src/core/engines/Cesium/Feature/index.tsx
+++ b/src/core/engines/Cesium/Feature/index.tsx
@@ -13,7 +13,12 @@ import Polyline, { config as polylineConfig } from "./Polyline";
 import Raster, { config as rasterConfig } from "./Raster";
 import Resource, { config as resourceConfig } from "./Resource";
 import Tileset, { config as tilesetConfig } from "./Tileset";
-import { extractSimpleLayerData, FeatureComponent, FeatureComponentConfig } from "./utils";
+import {
+  extractSimpleLayerData,
+  FeatureComponent,
+  FeatureComponentConfig,
+  generateIDWithMD5,
+} from "./utils";
 
 export * from "./utils";
 export { context, type Context } from "./context";
@@ -84,14 +89,20 @@ export default function Feature({
       <>
         {displayType.map(k => {
           const [C] = components[k] ?? [];
+          const isVisible = layer.layer.visible !== false && !isHidden;
+
+          // "noFeature" component should be recreated when the following value is changed.
+          // data.url, isVisible
+          const key = generateIDWithMD5(`${layer?.id || ""}_${k}_${data?.url}_${isVisible}`);
+
           return (
             <C
               {...props}
-              key={`${layer?.id || ""}_${k}_${data?.url}`}
+              key={key}
               id={`${layer.id}_${k}`}
               property={pickProperty(k, layer) || layer[k]}
               layer={layer}
-              isVisible={layer.layer.visible !== false && !isHidden}
+              isVisible={isVisible}
             />
           );
         })}

--- a/src/core/engines/Cesium/Feature/utils.tsx
+++ b/src/core/engines/Cesium/Feature/utils.tsx
@@ -11,6 +11,7 @@ import {
   TimeIntervalCollection as CesiumTimeIntervalCollection,
   DistanceDisplayCondition as CesiumDistanceDisplayCondition,
 } from "cesium";
+import md5 from "js-md5";
 import {
   ComponentProps,
   ComponentType,
@@ -188,4 +189,11 @@ export const toDistanceDisplayCondition = (
   return typeof near === "number" || typeof far === "number"
     ? new CesiumDistanceDisplayCondition(near ?? 0.0, far ?? Number.MAX_VALUE)
     : undefined;
+};
+
+export const generateIDWithMD5 = (id: string) => {
+  const hash = md5.create();
+  hash.update(id);
+
+  return hash.hex();
 };

--- a/src/core/mantle/atoms/compute.test.ts
+++ b/src/core/mantle/atoms/compute.test.ts
@@ -200,6 +200,24 @@ test("computeAtom", async () => {
     }),
   );
 
+  // delete computed features
+  act(() => {
+    result.current.set({
+      type: "deleteComputedFeatures",
+      features: ["c"],
+    });
+  });
+
+  await waitFor(() =>
+    expect(result.current.result).toEqual({
+      id: "xxx",
+      layer,
+      status: "ready",
+      features: [...toComputedFeature(features), ...toComputedFeature(features2)],
+      originalFeatures: [...features],
+    }),
+  );
+
   // delete delegatedDataTypes
   act(() => {
     result.current.set({ type: "updateDelegatedDataTypes", delegatedDataTypes: [] });
@@ -220,12 +238,12 @@ test("computeAtom", async () => {
     id: "xxx",
     layer,
     status: "fetching",
-    features: [...features, ...features2, ...features3].map(f => ({
+    features: [...features, ...features2].map(f => ({
       ...f,
       type: "computedFeature",
       marker: { pointColor: "red" },
     })),
-    originalFeatures: [...features, ...features3],
+    originalFeatures: [...features],
   });
 
   // delete a feature b
@@ -238,35 +256,7 @@ test("computeAtom", async () => {
     id: "xxx",
     layer,
     status: "fetching",
-    features: [
-      ...toComputedFeature(features),
-      ...toComputedFeature(features2),
-      ...toComputedFeature(features3),
-    ],
-    originalFeatures: [...features, ...features3],
-  });
-
-  await waitFor(() =>
-    expect(result.current.result).toEqual({
-      id: "xxx",
-      layer,
-      status: "ready",
-      features: [...toComputedFeature(features), ...toComputedFeature(features3)],
-      originalFeatures: [...features, ...features3],
-    }),
-  );
-
-  // delete a feature c
-  act(() => {
-    result.current.set({ type: "override" });
-    result.current.set({ type: "deleteFeatures", features: ["c"] });
-  });
-
-  expect(result.current.result).toEqual({
-    id: "xxx",
-    layer,
-    status: "fetching",
-    features: [...toComputedFeature(features), ...toComputedFeature(features3)],
+    features: [...toComputedFeature(features), ...toComputedFeature(features2)],
     originalFeatures: [...features],
   });
 
@@ -275,8 +265,32 @@ test("computeAtom", async () => {
       id: "xxx",
       layer,
       status: "ready",
-      features: toComputedFeature(features),
-      originalFeatures: features,
+      features: [...toComputedFeature(features)],
+      originalFeatures: [...features],
+    }),
+  );
+
+  // delete a feature "a"
+  act(() => {
+    result.current.set({ type: "override" });
+    result.current.set({ type: "deleteFeatures", features: ["a"] });
+  });
+
+  expect(result.current.result).toEqual({
+    id: "xxx",
+    layer,
+    status: "fetching",
+    features: [...toComputedFeature(features)],
+    originalFeatures: [],
+  });
+
+  await waitFor(() =>
+    expect(result.current.result).toEqual({
+      id: "xxx",
+      layer,
+      status: "ready",
+      features: [],
+      originalFeatures: [],
     }),
   );
 

--- a/src/util/idle.ts
+++ b/src/util/idle.ts
@@ -1,0 +1,22 @@
+const ctx = typeof window !== "undefined" ? window : global;
+const requestIdleCallbackShim = (
+  callback: (arg0: { didTimeout: boolean; timeRemaining: () => number }) => void,
+  _options?: IdleRequestOptions,
+) => {
+  const start = Date.now();
+  return ctx.setTimeout(function () {
+    callback({
+      didTimeout: false,
+      timeRemaining: function () {
+        return Math.max(0, 12 - (Date.now() - start));
+      },
+    });
+  });
+};
+const requestIdleCallback = ctx.requestIdleCallback || requestIdleCallbackShim;
+
+// This is used to schedule heavy required task at idle time.
+// But this task is required to advance process, so we want to execute it as fast as possible.
+export const requestIdleCallbackWithRequiredWork = (cb: () => void) => {
+  requestIdleCallback(cb, { timeout: 1 });
+};


### PR DESCRIPTION
# Overview

I fixed deleting feature process.

- Fixed to delete feature cached on atom when delegated feature is unmounted.
- Fixed to recreate noFeature component when `isVisible` is changed.

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
