### PR TITLE
fix: htmlblock on safari

### DIFF
--- a/src/components/molecules/Visualizer/Block/index.tsx
+++ b/src/components/molecules/Visualizer/Block/index.tsx
@@ -3,6 +3,7 @@ import { ComponentType } from "react";
 import { styled } from "@reearth/theme";
 import { ValueType, ValueTypes } from "@reearth/util/value";
 
+import { SceneProperty } from "../Engine";
 import { Viewport } from "../hooks";
 import Plugin from "../Plugin";
 import type { Block, Layer, InfoboxProperty, CommonProps as PluginCommonProps } from "../Plugin";
@@ -19,6 +20,7 @@ export type Props<BP = any> = {
   block?: Block<BP>;
   infoboxProperty?: InfoboxProperty;
   viewport?: Viewport;
+  theme?: SceneProperty["theme"];
   onClick?: () => void;
   onChange?: <T extends ValueType>(
     schemaItemId: string,

--- a/src/components/molecules/Visualizer/Block/index.tsx
+++ b/src/components/molecules/Visualizer/Block/index.tsx
@@ -3,7 +3,7 @@ import { ComponentType } from "react";
 import { styled } from "@reearth/theme";
 import { ValueType, ValueTypes } from "@reearth/util/value";
 
-import { SceneProperty } from "../Engine";
+import type { SceneProperty } from "../Engine";
 import { Viewport } from "../hooks";
 import Plugin from "../Plugin";
 import type { Block, Layer, InfoboxProperty, CommonProps as PluginCommonProps } from "../Plugin";

--- a/src/components/molecules/Visualizer/Infobox/index.tsx
+++ b/src/components/molecules/Visualizer/Infobox/index.tsx
@@ -125,6 +125,7 @@ const Infobox: React.FC<Props> = ({
             isEditable={isEditable}
             isBuilt={isBuilt}
             infoboxProperty={property}
+            theme={sceneProperty?.theme}
             pluginProperty={
               b.pluginId && b.extensionId
                 ? pluginProperty?.[`${b.pluginId}/${b.extensionId}`]

--- a/src/core/Crust/Infobox/Block/index.tsx
+++ b/src/core/Crust/Infobox/Block/index.tsx
@@ -4,6 +4,7 @@ import type { Layer } from "@reearth/core/mantle";
 import { styled } from "@reearth/theme";
 import type { ValueType, ValueTypes } from "@reearth/util/value";
 
+import { Theme } from "../../types";
 import type { Block, BlockProps, InfoboxProperty } from "../types";
 
 import builtin from "./builtin";
@@ -21,6 +22,7 @@ export type CommonProps<BP = any> = {
   isSelected?: boolean;
   block?: Block<BP>;
   infoboxProperty?: InfoboxProperty;
+  theme?: Theme;
   onClick?: () => void;
   onChange?: <T extends ValueType>(
     schemaItemId: string,

--- a/src/core/Crust/Infobox/index.tsx
+++ b/src/core/Crust/Infobox/index.tsx
@@ -125,6 +125,7 @@ const Infobox: React.FC<Props> = ({
             isEditable={isEditable}
             isBuilt={isBuilt}
             infoboxProperty={property}
+            theme={infoboxTheme}
             onChange={(...args) => onBlockChange?.(b.id, ...args, props.layer)}
             onClick={() => {
               if (b.id && selectedBlockId !== b.id) {


### PR DESCRIPTION
# Overview

Safari doesn't support load event with srcDoc, so I fixed to use `document.write()`...

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
