### PR TITLE
fix: add height to polygon in reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Polygon/index.tsx
+++ b/src/core/engines/Cesium/Feature/Polygon/index.tsx
@@ -45,6 +45,7 @@ export default function Polygon({
   const {
     show = true,
     fill = true,
+    height = 0,
     stroke,
     fillColor,
     strokeColor,
@@ -117,6 +118,7 @@ export default function Polygon({
         <PolygonGraphics
           hierarchy={hierarchy}
           fill={fill}
+          height={height}
           material={memoFillColor}
           outline={!!memoStrokeColor}
           outlineColor={memoStrokeColor}

--- a/src/core/mantle/types/appearance.ts
+++ b/src/core/mantle/types/appearance.ts
@@ -82,6 +82,7 @@ export type PolygonAppearance = {
   stroke?: boolean;
   strokeColor?: string;
   strokeWidth?: number;
+  height?: number;
   heightReference?: "none" | "clamp" | "relative";
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   lineJoin?: CanvasLineJoin;


### PR DESCRIPTION
# Overview
This PR adds support for height in polygon appearance and polygon graphic parameters in reearth/core.