### PR TITLE
perf: reduce style evaluator memory signature in reearth/core

### DIFF
--- a/src/core/mantle/evaluator/simple/expression/constants.ts
+++ b/src/core/mantle/evaluator/simple/expression/constants.ts
@@ -39,7 +39,6 @@ export const binaryOperators = [
   "=~",
 ];
 
-export const variableRegex = /\${(.*?)}/g; // Matches ${variable_name}
 export const backslashRegex = /\\/g;
 export const backslashReplacement = "@#%";
 export const replacementRegex = /@#%/g;

--- a/src/core/mantle/evaluator/simple/expression/expression.ts
+++ b/src/core/mantle/evaluator/simple/expression/expression.ts
@@ -12,7 +12,7 @@ export type JPLiteral = {
   literalValue: any;
 };
 
-const EXPRESSION_CACHES = new Map<string, Node | Error>();
+export const EXPRESSION_CACHES = new Map<string, Node | Error>();
 const DEFINE_PLACEHOLDER_REGEX_CACHE = new Map<string, RegExp>();
 
 export class Expression {

--- a/src/core/mantle/evaluator/simple/expression/expression.ts
+++ b/src/core/mantle/evaluator/simple/expression/expression.ts
@@ -1,7 +1,6 @@
 import jsep from "jsep";
 
 import { Feature } from "../../../types";
-import { defined } from "../../../utils";
 
 import { backslashRegex, backslashReplacement } from "./constants";
 import { Node } from "./node";
@@ -13,7 +12,8 @@ export type JPLiteral = {
   literalValue: any;
 };
 
-export const EXPRESSION_CACHES = new Map<string, Node | Error>();
+const EXPRESSION_CACHES = new Map<string, Node | Error>();
+const DEFINE_PLACEHOLDER_REGEX_CACHE = new Map<string, RegExp>();
 
 export class Expression {
   private _expression: string;
@@ -63,17 +63,17 @@ export class Expression {
 }
 
 export function replaceDefines(expression: string, defines: any): string {
-  if (!defined(defines)) {
+  if (typeof defines === "undefined") {
     return expression;
   }
-  for (const key in defines) {
-    const definePlaceholder = new RegExp(`\\$\\{${key}\\}`, "g");
-    const defineReplace = `(${defines[key]})`;
-    if (defined(defineReplace)) {
-      expression = expression.replace(definePlaceholder, defineReplace);
-    }
+  let definePlaceholderRegex = DEFINE_PLACEHOLDER_REGEX_CACHE.get(expression);
+  if (!definePlaceholderRegex) {
+    definePlaceholderRegex = new RegExp(`\\$\\{(${Object.keys(defines).join("|")})\\}`, "g");
+    DEFINE_PLACEHOLDER_REGEX_CACHE.set(expression, definePlaceholderRegex);
   }
-  return expression;
+  return expression.replace(definePlaceholderRegex, (_, key) =>
+    typeof defines[key] !== "undefined" ? `(${defines[key]})` : "",
+  );
 }
 
 export function removeBackslashes(expression: string): string {

--- a/src/core/mantle/evaluator/simple/expression/functions/colors.ts
+++ b/src/core/mantle/evaluator/simple/expression/functions/colors.ts
@@ -1,4 +1,4 @@
-import { defaultValue, defined } from "../../../../utils";
+import { defaultValue } from "../../../../utils";
 import { rgbaMatcher, rrggbbaaMatcher, builtInColor } from "../constants";
 
 //rgb(), rgba(), or rgb%()
@@ -32,7 +32,7 @@ export class Color {
     color = color.replace(/\s/g, "");
 
     const namedColor = getColor(color);
-    if (defined(namedColor)) {
+    if (typeof namedColor !== "undefined") {
       return namedColor;
     }
 
@@ -109,7 +109,7 @@ export class Color {
         blue = hue2rgb(m1, m2, hue - 1 / 3);
       }
 
-      if (!defined(result)) {
+      if (typeof result === "undefined") {
         return new Color(red, green, blue, alpha);
       }
 

--- a/src/core/mantle/evaluator/simple/expression/node.ts
+++ b/src/core/mantle/evaluator/simple/expression/node.ts
@@ -1,7 +1,6 @@
 import { Feature } from "../../../types";
-import { defined } from "../../../utils";
 
-import { ExpressionNodeType, variableRegex } from "./constants";
+import { ExpressionNodeType } from "./constants";
 import {
   getEvaluateUnaryFunction,
   unaryFunctions,
@@ -11,11 +10,11 @@ import {
 } from "./functions";
 
 export class Node {
-  _type;
-  _value;
-  _left;
-  _right;
-  _test;
+  private _type;
+  private _value;
+  private _left;
+  private _right;
+  private _test;
   evaluate: any;
 
   constructor(type: any, value: any, left?: any, right?: any, test?: any) {
@@ -29,80 +28,136 @@ export class Node {
   }
 
   setEvaluateFunction() {
-    if (this._type === ExpressionNodeType.CONDITIONAL) {
-      this.evaluate = this._evaluateConditional;
-    } else if (this._type === ExpressionNodeType.FUNCTION_CALL) {
-      if (this._value === "toString") {
-        this.evaluate = this._evaluateToString;
-      }
-    } else if (this._type === ExpressionNodeType.UNARY) {
-      if (this._value === "!") {
-        this.evaluate = this._evaluateNot;
-      } else if (this._value === "-") {
-        this.evaluate = this._evaluateNegative;
-      } else if (this._value === "+") {
-        this.evaluate = this._evaluatePositive;
-      } else if (this._value === "isNaN") {
-        this.evaluate = this._evaluateNaN;
-      } else if (this._value === "isFinite") {
-        this.evaluate = this._evaluateIsFinite;
-      } else if (this._value === "Boolean") {
-        this.evaluate = this._evaluateBooleanConversion;
-      } else if (this._value === "Number") {
-        this.evaluate = this._evaluateNumberConversion;
-      } else if (this._value === "String") {
-        this.evaluate = this._evaluateStringConversion;
-      } else if (defined(unaryFunctions[this._value as string])) {
-        this.evaluate = getEvaluateUnaryFunction(this._value);
-      }
-    } else if (this._type === ExpressionNodeType.BINARY) {
-      if (this._value === "+") {
-        this.evaluate = this._evaluatePlus;
-      } else if (this._value === "-") {
-        this.evaluate = this._evaluateMinus;
-      } else if (this._value === "*") {
-        this.evaluate = this._evaluateTimes;
-      } else if (this._value === "/") {
-        this.evaluate = this._evaluateDivide;
-      } else if (this._value === "%") {
-        this.evaluate = this._evaluateMod;
-      } else if (this._value === "===") {
-        this.evaluate = this._evaluateEqualsStrict;
-      } else if (this._value === "!==") {
-        this.evaluate = this._evaluateNotEqualsStrict;
-      } else if (this._value === "<") {
-        this.evaluate = this._evaluateLessThan;
-      } else if (this._value === "<=") {
-        this.evaluate = this._evaluateLessThanOrEquals;
-      } else if (this._value === ">") {
-        this.evaluate = this._evaluateGreaterThan;
-      } else if (this._value === ">=") {
-        this.evaluate = this._evaluateGreaterThanOrEquals;
-      } else if (this._value === "&&") {
-        this.evaluate = this._evaluateAnd;
-      } else if (this._value === "||") {
-        this.evaluate = this._evaluateOr;
-      } else if (defined(binaryFunctions[this._value])) {
-        this.evaluate = getEvaluateBinaryFunction(this._value);
-      }
-    } else if (this._type === ExpressionNodeType.MEMBER) {
-      if (this._value === "brackets") {
-        this.evaluate = this._evaluateMemberBrackets;
-      } else {
-        this.evaluate = this._evaluateMemberDot;
-      }
-    } else if (this._type === ExpressionNodeType.ARRAY) {
-      this.evaluate = this._evaluateArray;
-    } else if (this._type === ExpressionNodeType.VARIABLE) {
-      this.evaluate = this._evaluateVariable;
-    } else if (this._type === ExpressionNodeType.VARIABLE_IN_STRING) {
-      this.evaluate = this._evaluateVariableString;
-    } else if (this._type === ExpressionNodeType.LITERAL_COLOR) {
-      this.evaluate = this._evaluateLiteralColor;
-    } else if (this._type === ExpressionNodeType.LITERAL_STRING) {
-      this.evaluate = this._evaluateLiteralString;
-    } else {
-      this.evaluate = this._evaluateLiteral;
+    const type = this._type;
+    const value = this._value;
+
+    switch (type) {
+      case ExpressionNodeType.CONDITIONAL:
+        this.evaluate = this._evaluateConditional;
+        break;
+
+      case ExpressionNodeType.FUNCTION_CALL:
+        switch (value) {
+          case "toString":
+            this.evaluate = this._evaluateToString;
+            break;
+        }
+        break;
+
+      case ExpressionNodeType.UNARY:
+        switch (value) {
+          case "!":
+            this.evaluate = this._evaluateNot;
+            break;
+          case "-":
+            this.evaluate = this._evaluateNegative;
+            break;
+          case "+":
+            this.evaluate = this._evaluatePositive;
+            break;
+          case "isNaN":
+            this.evaluate = this._evaluateNaN;
+            break;
+          case "isFinite":
+            this.evaluate = this._evaluateIsFinite;
+            break;
+          case "Boolean":
+            this.evaluate = this._evaluateBooleanConversion;
+            break;
+          case "Number":
+            this.evaluate = this._evaluateNumberConversion;
+            break;
+          case "String":
+            this.evaluate = this._evaluateStringConversion;
+            break;
+          default:
+            if (typeof unaryFunctions[value as string] !== "undefined") {
+              this.evaluate = getEvaluateUnaryFunction(value);
+            }
+            break;
+        }
+        break;
+
+      case ExpressionNodeType.BINARY:
+        switch (value) {
+          case "+":
+            this.evaluate = this._evaluatePlus;
+            break;
+          case "-":
+            this.evaluate = this._evaluateMinus;
+            break;
+          case "*":
+            this.evaluate = this._evaluateTimes;
+            break;
+          case "/":
+            this.evaluate = this._evaluateDivide;
+            break;
+          case "%":
+            this.evaluate = this._evaluateMod;
+            break;
+          case "===":
+            this.evaluate = this._evaluateEqualsStrict;
+            break;
+          case "!==":
+            this.evaluate = this._evaluateNotEqualsStrict;
+            break;
+          case "<":
+            this.evaluate = this._evaluateLessThan;
+            break;
+          case "<=":
+            this.evaluate = this._evaluateLessThanOrEquals;
+            break;
+          case ">":
+            this.evaluate = this._evaluateGreaterThan;
+            break;
+          case ">=":
+            this.evaluate = this._evaluateGreaterThanOrEquals;
+            break;
+          case "&&":
+            this.evaluate = this._evaluateAnd;
+            break;
+          case "||":
+            this.evaluate = this._evaluateOr;
+            break;
+          default:
+            if (typeof binaryFunctions[value] !== "undefined") {
+              this.evaluate = getEvaluateBinaryFunction(value);
+            }
+            break;
+        }
+        break;
+
+      case ExpressionNodeType.MEMBER:
+        if (value === "brackets") {
+          this.evaluate = this._evaluateMemberBrackets;
+        } else {
+          this.evaluate = this._evaluateMemberDot;
+        }
+        break;
+
+      case ExpressionNodeType.ARRAY:
+        this.evaluate = this._evaluateArray;
+        break;
+
+      case ExpressionNodeType.VARIABLE:
+        this.evaluate = this._evaluateVariable;
+        break;
+
+      case ExpressionNodeType.VARIABLE_IN_STRING:
+        this.evaluate = this._evaluateVariableString;
+        break;
+
+      case ExpressionNodeType.LITERAL_COLOR:
+        this.evaluate = this._evaluateLiteralColor;
+        break;
+
+      case ExpressionNodeType.LITERAL_STRING:
+        this.evaluate = this._evaluateLiteralString;
+        break;
+
+      default:
+        this.evaluate = this._evaluateLiteral;
+        break;
     }
   }
 
@@ -113,13 +168,14 @@ export class Node {
     return this._value;
   }
   _evaluateVariableString(feature?: Feature) {
+    const variableRegex = /\${(.*?)}/g;
     let result = this._value;
     let match = variableRegex.exec(result);
     while (match !== null) {
       const placeholder = match[0];
       const variableName = match[1];
       let property = feature?.properties[variableName];
-      if (!defined(property)) {
+      if (typeof property === "undefined") {
         property = "";
       }
       result = result.replace(placeholder, property);
@@ -134,7 +190,7 @@ export class Node {
     } else if (String(this._value) === "id") {
       property = feature?.id;
     }
-    if (!defined(property)) {
+    if (typeof property === "undefined") {
       property = "";
     }
     return property;
@@ -144,7 +200,7 @@ export class Node {
       return feature?.properties[this._right.evaluate(feature)];
     }
     const property = this._left.evaluate(feature);
-    if (!defined(property)) {
+    if (typeof property === "undefined") {
       return undefined;
     }
 
@@ -157,7 +213,7 @@ export class Node {
       return feature?.properties[this._right.evaluate(feature)];
     }
     const property = this._left.evaluate(feature);
-    if (!defined(property)) {
+    if (typeof property === "undefined") {
       return undefined;
     }
 
@@ -389,7 +445,7 @@ export class Node {
     const args = this._left;
     let color = new Color();
     if (this._value === "color") {
-      if (!defined(args)) {
+      if (typeof args === "undefined") {
         color = Color.fromBytes(255, 255, 255, 255);
       } else if (args.length > 1) {
         const temp = Color.fromCssColorString(args[0].evaluate(feature));

--- a/src/core/mantle/evaluator/simple/expression/variableReplacer.ts
+++ b/src/core/mantle/evaluator/simple/expression/variableReplacer.ts
@@ -1,8 +1,5 @@
 import { JSONPath } from "jsonpath-plus";
 
-import { Feature } from "../../../types";
-import { defined } from "../../../utils";
-
 import { JPLiteral } from "./expression";
 import { generateRandomString } from "./utils";
 
@@ -11,42 +8,47 @@ export function replaceVariables(expression: string, feature?: any): [string, JP
   let result = "";
   const literalJP: JPLiteral[] = [];
   let i = exp.indexOf("${");
+  const featureDefined = typeof feature !== "undefined";
+  const jsonPathCache: Record<string, any[]> = {};
+  const varExpRegex = /^\$./;
   while (i >= 0) {
     if (isInsideQuotes(exp, i)) {
       const closeQuote = findCloseQuote(exp, i);
-      result += exp.substring(0, closeQuote + 1);
-      exp = exp.substring(closeQuote + 1);
+      result += exp.slice(0, closeQuote + 1);
+      exp = exp.slice(closeQuote + 1);
       i = exp.indexOf("${");
     } else {
-      result += exp.substring(0, i);
+      result += exp.slice(0, i);
       const j = getCloseBracketIndex(exp, i);
-      const varExp = exp.substring(i + 2, j);
-      if (varExp.substring(0, 2) === "$.") {
-        if (!defined(feature)) {
-          throw new Error(`replaceVariable: features need to be defined for JSONPath`);
+      const varExp = exp.slice(i + 2, j);
+      if (varExpRegex.test(varExp)) {
+        if (!featureDefined) {
+          return [result, []];
         }
-        if (containsValidJSONPath(varExp, feature)) {
-          const res = JSONPath({ json: feature, path: varExp });
-          if (res.length == 1) {
-            const placeholderLiteral = generateRandomString(10);
-            literalJP.push({
-              literalName: placeholderLiteral,
-              literalValue: res[0],
-            });
-            result += placeholderLiteral;
-          } else if (res.length < 1) {
-            throw new Error(`replaceVariable: ${varExp} gives none`);
-          } else {
-            throw new Error(`replaceVariable: ${varExp} should give only one result`);
+        let res = jsonPathCache[varExp];
+        if (!res) {
+          try {
+            res = JSONPath({ json: feature, path: varExp });
+            jsonPathCache[varExp] = res;
+          } catch (error) {
+            return [result, []];
           }
+        }
+        if (res.length == 1) {
+          const placeholderLiteral = generateRandomString(10);
+          literalJP.push({
+            literalName: placeholderLiteral,
+            literalValue: res[0],
+          });
+          result += placeholderLiteral;
         } else {
-          throw new Error(`replaceVariable: ${varExp} is not a valid JSONPath`);
+          return [result, []];
         }
       } else {
         const replacedVarExp = replaceReservedWord(varExp);
         result += `czm_${replacedVarExp}`;
       }
-      exp = exp.substring(j + 1);
+      exp = exp.slice(j + 1);
       i = exp.indexOf("${");
     }
   }
@@ -86,15 +88,6 @@ function getCloseBracketIndex(exp: string, openBracketIndex: number): number {
     throw new Error(`replaceVariable: Unmatched {.`);
   }
   return j;
-}
-
-function containsValidJSONPath(expression: string, feature: Feature): boolean {
-  try {
-    JSONPath({ json: feature, path: expression });
-    return true;
-  } catch (error) {
-    return false;
-  }
 }
 
 const makeReservedWord = (str: string) => `$reearth_${str}_$`;


### PR DESCRIPTION
# Overview
I added some performance optimisations for the style evaluator which includes using 
1. using `switch-case` for long chain of `if-else`.
2. use less heavy string operations in replaceVariable.
2. Memoization of the regularly used regex.
3. Remove a highly imported function(`defined`) which is relatively slower than `typeOf`.
4. Using private fields instead of using prefix `#`