### PR TITLE
feat: option to unselect layer when click infobox close

### DIFF
--- a/src/core/Crust/Infobox/Frame/index.tsx
+++ b/src/core/Crust/Infobox/Frame/index.tsx
@@ -23,6 +23,7 @@ export type Props = {
   size?: "small" | "medium" | "large";
   position?: "right" | "middle" | "left";
   visible?: boolean;
+  unselectOnClose?: boolean;
   noContent?: boolean;
   useMask?: boolean;
   typography?: Typography;
@@ -54,6 +55,7 @@ const Frame: React.FC<Props> = ({
   outlineColor,
   outlineWidth,
   visible,
+  unselectOnClose,
   noContent,
   useMask,
   typography,
@@ -86,9 +88,11 @@ const Frame: React.FC<Props> = ({
   }, [open, noContent, isSmallWindow]);
 
   const handleClose = useCallback(() => {
-    setOpen(false);
+    if (!unselectOnClose) {
+      setOpen(false);
+    }
     onClose?.();
-  }, [onClose]);
+  }, [onClose, unselectOnClose]);
 
   useEffect(() => {
     if (!ref2.current) return;

--- a/src/core/Crust/Infobox/Frame/index.tsx
+++ b/src/core/Crust/Infobox/Frame/index.tsx
@@ -23,6 +23,7 @@ export type Props = {
   size?: "small" | "medium" | "large";
   position?: "right" | "middle" | "left";
   visible?: boolean;
+  hideOnClose?: boolean;
   noContent?: boolean;
   useMask?: boolean;
   typography?: Typography;
@@ -53,6 +54,7 @@ const Frame: React.FC<Props> = ({
   outlineColor,
   outlineWidth,
   visible,
+  hideOnClose,
   noContent,
   useMask,
   typography,
@@ -75,6 +77,7 @@ const Frame: React.FC<Props> = ({
   const ref = useRef<HTMLDivElement>(null);
   const ref2 = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(true);
+  const [actualVisible, setActualVisible] = useState(visible);
   const [showMask, setShowMask] = useState<boolean | undefined>(false);
   useClickAway(ref, () => onClickAway?.());
 
@@ -84,8 +87,12 @@ const Frame: React.FC<Props> = ({
   }, [open, noContent, isSmallWindow]);
 
   const handleClose = useCallback(() => {
-    setOpen(false);
-  }, []);
+    if (hideOnClose) {
+      setActualVisible(false);
+    } else {
+      setOpen(false);
+    }
+  }, [hideOnClose]);
 
   useEffect(() => {
     if (!ref2.current) return;
@@ -94,12 +101,16 @@ const Frame: React.FC<Props> = ({
   }, [infoboxKey]);
 
   useEffect(() => {
-    if (!visible) {
+    if (!actualVisible) {
       setOpen(true);
     }
     setTimeout(() => {
-      setShowMask(visible);
+      setShowMask(actualVisible);
     }, 0);
+  }, [actualVisible]);
+
+  useEffect(() => {
+    setActualVisible(visible);
   }, [visible]);
 
   const wrapperStyles = useMemo(
@@ -115,7 +126,7 @@ const Frame: React.FC<Props> = ({
       <Mask activate={showMask && useMask} onClick={onMaskClick} />
       <StyledFloatedPanel
         className={className}
-        visible={visible}
+        visible={actualVisible}
         open={open}
         styles={wrapperStyles}
         onClick={onClick}

--- a/src/core/Crust/Infobox/Frame/index.tsx
+++ b/src/core/Crust/Infobox/Frame/index.tsx
@@ -23,7 +23,6 @@ export type Props = {
   size?: "small" | "medium" | "large";
   position?: "right" | "middle" | "left";
   visible?: boolean;
-  hideOnClose?: boolean;
   noContent?: boolean;
   useMask?: boolean;
   typography?: Typography;
@@ -40,6 +39,7 @@ export type Props = {
   onEntered?: () => void;
   onExit?: () => void;
   onExited?: () => void;
+  onClose?: () => void;
 };
 
 const Frame: React.FC<Props> = ({
@@ -54,7 +54,6 @@ const Frame: React.FC<Props> = ({
   outlineColor,
   outlineWidth,
   visible,
-  hideOnClose,
   noContent,
   useMask,
   typography,
@@ -72,12 +71,12 @@ const Frame: React.FC<Props> = ({
   onEntered,
   onExit,
   onExited,
+  onClose,
 }) => {
   const isSmallWindow = useMedia("(max-width: 624px)");
   const ref = useRef<HTMLDivElement>(null);
   const ref2 = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(true);
-  const [actualVisible, setActualVisible] = useState(visible);
   const [showMask, setShowMask] = useState<boolean | undefined>(false);
   useClickAway(ref, () => onClickAway?.());
 
@@ -87,12 +86,9 @@ const Frame: React.FC<Props> = ({
   }, [open, noContent, isSmallWindow]);
 
   const handleClose = useCallback(() => {
-    if (hideOnClose) {
-      setActualVisible(false);
-    } else {
-      setOpen(false);
-    }
-  }, [hideOnClose]);
+    setOpen(false);
+    onClose?.();
+  }, [onClose]);
 
   useEffect(() => {
     if (!ref2.current) return;
@@ -101,16 +97,12 @@ const Frame: React.FC<Props> = ({
   }, [infoboxKey]);
 
   useEffect(() => {
-    if (!actualVisible) {
+    if (!visible) {
       setOpen(true);
     }
     setTimeout(() => {
-      setShowMask(actualVisible);
+      setShowMask(visible);
     }, 0);
-  }, [actualVisible]);
-
-  useEffect(() => {
-    setActualVisible(visible);
   }, [visible]);
 
   const wrapperStyles = useMemo(
@@ -126,7 +118,7 @@ const Frame: React.FC<Props> = ({
       <Mask activate={showMask && useMask} onClick={onMaskClick} />
       <StyledFloatedPanel
         className={className}
-        visible={actualVisible}
+        visible={visible}
         open={open}
         styles={wrapperStyles}
         onClick={onClick}

--- a/src/core/Crust/Infobox/index.tsx
+++ b/src/core/Crust/Infobox/index.tsx
@@ -25,6 +25,7 @@ export type Props = {
   isBuilt?: boolean;
   selectedBlockId?: string;
   visible?: boolean;
+  hideOnClose?: boolean;
   theme?: Theme;
   layer?: Layer;
   onMaskClick?: () => void;
@@ -88,6 +89,7 @@ const Infobox: React.FC<Props> = ({
       useMask={!!property?.useMask}
       outlineWidth={property?.outlineWidth}
       visible={visible}
+      hideOnClose={property?.hideOnClose}
       noContent={!blocks?.length}
       theme={infoboxTheme}
       backgroundColor={property?.bgcolor}

--- a/src/core/Crust/Infobox/index.tsx
+++ b/src/core/Crust/Infobox/index.tsx
@@ -25,7 +25,6 @@ export type Props = {
   isBuilt?: boolean;
   selectedBlockId?: string;
   visible?: boolean;
-  hideOnClose?: boolean;
   theme?: Theme;
   layer?: Layer;
   onMaskClick?: () => void;
@@ -43,6 +42,7 @@ export type Props = {
   onBlockInsert?: (bi: number, i: number, pos?: "top" | "bottom") => void;
   renderBlock?: (block: BlockProps) => ReactNode;
   renderInsertionPopup?: (onSelect: (bi: number) => void, onClose: () => void) => ReactNode;
+  onClose?: () => void;
 };
 
 const Infobox: React.FC<Props> = ({
@@ -62,6 +62,7 @@ const Infobox: React.FC<Props> = ({
   onBlockMove,
   onBlockInsert,
   renderInsertionPopup,
+  onClose,
   ...props
 }) => {
   const {
@@ -89,7 +90,6 @@ const Infobox: React.FC<Props> = ({
       useMask={!!property?.useMask}
       outlineWidth={property?.outlineWidth}
       visible={visible}
-      hideOnClose={property?.hideOnClose}
       noContent={!blocks?.length}
       theme={infoboxTheme}
       backgroundColor={property?.bgcolor}
@@ -103,7 +103,8 @@ const Infobox: React.FC<Props> = ({
       onClick={() => selectedBlockId && onBlockSelect?.(undefined)}
       onEnter={setNotReadyToRender}
       onEntered={setReadyToRender}
-      onExit={setNotReadyToRender}>
+      onExit={setNotReadyToRender}
+      onClose={onClose}>
       {blocks?.map((b, i) => (
         <Field
           key={b.id}

--- a/src/core/Crust/Infobox/index.tsx
+++ b/src/core/Crust/Infobox/index.tsx
@@ -90,6 +90,7 @@ const Infobox: React.FC<Props> = ({
       useMask={!!property?.useMask}
       outlineWidth={property?.outlineWidth}
       visible={visible}
+      unselectOnClose={property?.unselectOnClose}
       noContent={!blocks?.length}
       theme={infoboxTheme}
       backgroundColor={property?.bgcolor}

--- a/src/core/Crust/Infobox/types.ts
+++ b/src/core/Crust/Infobox/types.ts
@@ -21,6 +21,7 @@ export type InfoboxProperty = {
   outlineWidth?: number;
   useMask?: boolean;
   defaultContent?: "description" | "attributes";
+  hideOnClose?: boolean;
 };
 
 export type Block<P = any> = {

--- a/src/core/Crust/Infobox/types.ts
+++ b/src/core/Crust/Infobox/types.ts
@@ -21,7 +21,7 @@ export type InfoboxProperty = {
   outlineWidth?: number;
   useMask?: boolean;
   defaultContent?: "description" | "attributes";
-  hideOnClose?: boolean;
+  unselectOnClose?: boolean;
 };
 
 export type Block<P = any> = {

--- a/src/core/Crust/index.tsx
+++ b/src/core/Crust/index.tsx
@@ -93,6 +93,7 @@ export type Props = {
   onWidgetAreaSelect?: (widgetArea?: WidgetAreaType) => void;
   // infobox events
   onInfoboxMaskClick?: () => void;
+  onInfoboxClose?: () => void;
   onBlockSelect?: (id?: string) => void;
   onBlockChange?: <T extends ValueType>(
     blockId: string,
@@ -141,6 +142,7 @@ export default function Crust({
   onWidgetAlignmentUpdate,
   onWidgetAreaSelect,
   onInfoboxMaskClick,
+  onInfoboxClose,
   onBlockSelect,
   onBlockChange,
   onBlockMove,
@@ -225,6 +227,7 @@ export default function Crust({
         onBlockInsert={onBlockInsert}
         renderBlock={renderBlock}
         renderInsertionPopup={renderInfoboxInsertionPopup}
+        onClose={onInfoboxClose}
       />
     </Plugins>
   );

--- a/src/core/Visualizer/hooks.ts
+++ b/src/core/Visualizer/hooks.ts
@@ -95,7 +95,6 @@ export default function useHooks({
   const [selectedComputedFeature, selectComputedFeature] = useState<ComputedFeature>();
   useEffect(() => {
     const { layerId, featureId, layer, reason } = selectedLayer;
-    console.log("onLayerSelect", onLayerSelect);
     onLayerSelect?.(layerId, featureId, async () => layer, reason);
   }, [onLayerSelect, selectedLayer]);
   const handleLayerSelect = useCallback(
@@ -143,9 +142,7 @@ export default function useHooks({
   );
   const handleInfoboxClose = useCallback(() => {
     if (infobox?.property?.unselectOnClose) {
-      selectLayer({});
-      selectFeature(undefined);
-      selectComputedFeature(undefined);
+      mapRef?.current?.layers.select(undefined);
     }
   }, [infobox]);
 

--- a/src/core/Visualizer/hooks.ts
+++ b/src/core/Visualizer/hooks.ts
@@ -95,6 +95,7 @@ export default function useHooks({
   const [selectedComputedFeature, selectComputedFeature] = useState<ComputedFeature>();
   useEffect(() => {
     const { layerId, featureId, layer, reason } = selectedLayer;
+    console.log("onLayerSelect", onLayerSelect);
     onLayerSelect?.(layerId, featureId, async () => layer, reason);
   }, [onLayerSelect, selectedLayer]);
   const handleLayerSelect = useCallback(
@@ -140,6 +141,13 @@ export default function useHooks({
         : undefined,
     [selectedLayer, defaultInfobox, blocks],
   );
+  const handleInfoboxClose = useCallback(() => {
+    if (infobox?.property?.unselectOnClose) {
+      selectLayer({});
+      selectFeature(undefined);
+      selectComputedFeature(undefined);
+    }
+  }, [infobox]);
 
   // scene
   const [overriddenSceneProperty, overrideSceneProperty] = useOverriddenProperty(sceneProperty);
@@ -264,6 +272,7 @@ export default function useHooks({
     overrideSceneProperty,
     handleLayerEdit,
     onLayerEdit,
+    handleInfoboxClose,
   };
 }
 

--- a/src/core/Visualizer/index.tsx
+++ b/src/core/Visualizer/index.tsx
@@ -171,6 +171,7 @@ export default function Visualizer({
     overrideSceneProperty,
     handleLayerEdit,
     onLayerEdit,
+    handleInfoboxClose,
   } = useHooks({
     rootLayerId,
     isEditable,
@@ -227,6 +228,7 @@ export default function Visualizer({
         onWidgetAlignmentUpdate={onWidgetAlignmentUpdate}
         onWidgetAreaSelect={onWidgetAreaSelect}
         onInfoboxMaskClick={onInfoboxMaskClick}
+        onInfoboxClose={handleInfoboxClose}
         onBlockSelect={handleBlockSelect}
         onBlockChange={onBlockChange}
         onBlockMove={onBlockMove}

--- a/src/core/mantle/compat/types.ts
+++ b/src/core/mantle/compat/types.ts
@@ -42,6 +42,7 @@ export type InfoboxProperty = {
     outlineWidth?: number;
     useMask?: boolean;
     defaultContent?: "description" | "attributes";
+    unselectOnClose?: boolean;
   };
 };
 


### PR DESCRIPTION
# Overview

Infobox shows a small UI panel when click close button. 

This PR adds a `unselectOnClose` property to infobox so that infobox can trigger a unselect on close and the UI will be fully invisible automatically.

## What I've done

- Add property `unselectOnClose`
- Unselect layer when infobox close and unselectOnClose is true.

## What I haven't done

- Did not add this property on reearth backend. It's useful for infobox added by plugin API but can't be set with reearth editor.

## How I tested

Test with:
```javascript
reearth.layers.add({
  type: "simple",
  data: { 
    type: "geojson",
    value: {
      "type": "Feature",
      "geometry": {
        "coordinates": [-15, 20, 10000],
        "type": "Point"
      }
    }
  },
  marker: {},
  infobox: {
    blocks: [],
    property: {
      default: {
        title: 'Unselect On Close',
        unselectOnClose: true
      }
    }
  }
});

reearth.layers.add({
  type: "simple",
  data: { 
    type: "geojson",
    value: {
      "type": "Feature",
      "geometry": {
        "coordinates": [-16, 20, 10000],
        "type": "Point"
      }
    }
  },
  marker: {},
  infobox: {
    blocks: [],
    property: {
      default: {
        title: 'Default Close',
      }
    }
  }
});
```

## Screenshot


https://user-images.githubusercontent.com/21994748/226797586-e24c178b-49a4-4590-9704-f30293fca4cc.mp4



## Which point I want you to review particularly

## Memo

