### PR TITLE
fix: revert add height to polygon in reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Polygon/index.tsx
+++ b/src/core/engines/Cesium/Feature/Polygon/index.tsx
@@ -45,7 +45,6 @@ export default function Polygon({
   const {
     show = true,
     fill = true,
-    height = 0,
     stroke,
     fillColor,
     strokeColor,
@@ -118,7 +117,6 @@ export default function Polygon({
         <PolygonGraphics
           hierarchy={hierarchy}
           fill={fill}
-          height={height}
           material={memoFillColor}
           outline={!!memoStrokeColor}
           outlineColor={memoStrokeColor}

--- a/src/core/mantle/types/appearance.ts
+++ b/src/core/mantle/types/appearance.ts
@@ -82,7 +82,6 @@ export type PolygonAppearance = {
   stroke?: boolean;
   strokeColor?: string;
   strokeWidth?: number;
-  height?: number;
   heightReference?: "none" | "clamp" | "relative";
   shadows?: "disabled" | "enabled" | "cast_only" | "receive_only";
   lineJoin?: CanvasLineJoin;


### PR DESCRIPTION
Reverts reearth/reearth-web#557

As discussed this fix doesn't work well with clampToGround the polygon. 