### PR TITLE
fix: add clamp as default height reference for model in reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Model/index.tsx
+++ b/src/core/engines/Cesium/Feature/Model/index.tsx
@@ -45,7 +45,7 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
     show = true,
     model,
     url,
-    heightReference: hr,
+    heightReference: hr = "clamp",
     heading,
     pitch,
     roll,


### PR DESCRIPTION
# Overview
This PR adds clamp as default Height reference for model in reearth/core. When done from the plugin its seems to be causing issues for the polygon data.