### PR TITLE
fix: sample terrain height API cannot properly return promise

### DIFF
--- a/src/core/Crust/Plugins/api.ts
+++ b/src/core/Crust/Plugins/api.ts
@@ -158,6 +158,13 @@ export function exposed({
               overrideSceneProperty?.(plugin ? `${plugin.id}/${plugin.extensionId}` : "", property);
             };
           },
+          get sampleTerrainHeight() {
+            return async (lng: number, lat: number) => {
+              const result = await commonReearth?.scene?.sampleTerrainHeight?.(lng, lat);
+              startEventLoop?.();
+              return result;
+            };
+          },
         }),
         plugin: {
           get id() {


### PR DESCRIPTION
# Overview

Add `startEventLoop` for trigger event on vm.

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
