### PR TITLE
feat: add more styling properties to resource appearance in reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -1,4 +1,4 @@
-import { Entity, type DataSource } from "cesium";
+import { Entity, type DataSource, Color } from "cesium";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { KmlDataSource, CzmlDataSource, GeoJsonDataSource, useCesium } from "resium";
 
@@ -44,7 +44,15 @@ export default function Resource({
   onComputedFeatureFetch,
   onComputedFeatureDelete,
 }: Props) {
-  const { show = true, clampToGround } = property ?? {};
+  const {
+    show = true,
+    clampToGround,
+    stroke,
+    strokeWidth,
+    markerColor,
+    markerSize,
+    fill,
+  } = property ?? {};
   const [type, url, updateClock] = useMemo((): [
     ResourceAppearance["type"],
     string | undefined,
@@ -150,6 +158,11 @@ export default function Resource({
       clampToGround={clampToGround}
       onChange={handleChange}
       onLoad={handleLoad}
+      stroke={Color.fromCssColorString(stroke ?? "white")}
+      fill={Color.fromCssColorString(fill ?? "transparent")}
+      strokeWidth={strokeWidth}
+      markerSize={markerSize}
+      markerColor={Color.fromCssColorString(markerColor ?? "white")}
     />
   );
 }

--- a/src/core/mantle/types/appearance.ts
+++ b/src/core/mantle/types/appearance.ts
@@ -166,6 +166,11 @@ export type ResourceAppearance = {
   url?: string;
   type?: "geojson" | "kml" | "czml" | "auto";
   clampToGround?: boolean;
+  markerSize?: number;
+  markerColor?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  fill?: string;
 };
 
 export type RasterAppearance = {


### PR DESCRIPTION
# Overview
This PR adds more styling option on Resource Apperance in reearth/core and related refactors.

