### PR TITLE
fix: remove default height reference for modelGraphics in reearth/core

### DIFF
--- a/src/core/engines/Cesium/Feature/Model/index.tsx
+++ b/src/core/engines/Cesium/Feature/Model/index.tsx
@@ -45,7 +45,7 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
     show = true,
     model,
     url,
-    heightReference: hr = "clamp",
+    heightReference: hr,
     heading,
     pitch,
     roll,


### PR DESCRIPTION
# Overview
This PR removes the `default` height reference(clamp) for the Model Graphics as it is making it impossible to render some `glb` or `glTF` files.
