### PR TITLE
feat: support styling color & show for 3dtiles model

### DIFF
--- a/src/core/engines/Cesium/Feature/Tileset/hooks.ts
+++ b/src/core/engines/Cesium/Feature/Tileset/hooks.ts
@@ -95,13 +95,18 @@ type CachedFeature = {
 
 const MAX_NUMBER_OF_CONCURRENT_COMPUTING_FEATURES = 5000;
 
-type StyleProperty<N = string> = { name: N; convert?: "color" | "vec2" | "vec4" };
+type StyleProperty<N = string> = {
+  name: N;
+  convert?: "color" | "colorFunctionString" | "booleanString" | "vec2" | "vec4";
+};
 
 const COMMON_STYLE_PROPERTIES: StyleProperty<"color" | "show">[] = [
   { name: "color", convert: "color" },
   { name: "show" },
 ];
-const MODEL_STYLE_PROPERTIES: StyleProperty<"pointSize" | "meta">[] = [
+const MODEL_STYLE_PROPERTIES: StyleProperty<"color" | "show" | "pointSize" | "meta">[] = [
+  { name: "color", convert: "colorFunctionString" },
+  { name: "show", convert: "booleanString" },
   { name: "pointSize" },
   { name: "meta" },
 ];
@@ -119,6 +124,10 @@ const TILESET_APPEARANCE_FIELDS: (keyof Cesium3DTilesAppearance)[] = [
 const convertStyle = (val: any, convert: StyleProperty["convert"]) => {
   if (convert === "color") {
     return toColor(val);
+  } else if (convert === "colorFunctionString") {
+    return `color("${val}")`;
+  } else if (convert === "booleanString") {
+    return typeof val === "boolean" ? (val ? "true" : "false") : val;
   }
 
   return val;

--- a/src/core/engines/Cesium/Feature/Tileset/hooks.ts
+++ b/src/core/engines/Cesium/Feature/Tileset/hooks.ts
@@ -97,7 +97,7 @@ const MAX_NUMBER_OF_CONCURRENT_COMPUTING_FEATURES = 5000;
 
 type StyleProperty<N = string> = {
   name: N;
-  convert?: "color" | "colorFunctionString" | "booleanString" | "vec2" | "vec4";
+  convert?: "color" | "colorFunctionString" | "vec2" | "vec4";
 };
 
 const COMMON_STYLE_PROPERTIES: StyleProperty<"color" | "show">[] = [
@@ -106,7 +106,7 @@ const COMMON_STYLE_PROPERTIES: StyleProperty<"color" | "show">[] = [
 ];
 const MODEL_STYLE_PROPERTIES: StyleProperty<"color" | "show" | "pointSize" | "meta">[] = [
   { name: "color", convert: "colorFunctionString" },
-  { name: "show", convert: "booleanString" },
+  { name: "show" },
   { name: "pointSize" },
   { name: "meta" },
 ];
@@ -126,8 +126,6 @@ const convertStyle = (val: any, convert: StyleProperty["convert"]) => {
     return toColor(val);
   } else if (convert === "colorFunctionString") {
     return `color("${val}")`;
-  } else if (convert === "booleanString") {
-    return typeof val === "boolean" ? (val ? "true" : "false") : val;
   }
 
   return val;
@@ -180,7 +178,7 @@ const useFeature = ({
             // TODO: Convert value if it's necessary
             MODEL_STYLE_PROPERTIES.reduce((res, { name, convert }) => {
               const val = convertStyle(style?.[name as keyof typeof style], convert);
-              if (!val) return res;
+              if (val === undefined) return res;
               return { ...res, [name]: val };
             }, {}),
           );


### PR DESCRIPTION
# Overview

3dtiles with no features are rendered as model, therefore the style of `coloe` `show` should also been included.

## What I've done

- Add `show` `color` to `MODEL_STYLE_PROPERTIES`
- Convert `show` `color` to match the type of style object for new Cesium3DTileStyle().

## What I haven't done

## How I tested

```js
reearth.layers.add({
  type: 'simple',
  data: {
    type: '3dtiles',
    url: "https://assets.cms.plateau.reearth.io/assets/0a/a2581a-e2cd-462a-a78b-a86841c477e9/uc22-024_sensynrobotics_kawasaki_build_2/tileset.json"
  },
  "3dtiles": {
    show: {
      "expression": {
        "conditions": [
          [
              "true",
              "true"
          ]
        ]
      }
    },
    color: {
      "expression": {
        "conditions": [
          [
              "true",
              "rgba(255,0,0,0.5)"
          ]
        ]
      }
    }
  }
})
```
## Screenshot

![image](https://user-images.githubusercontent.com/21994748/230076164-52a02a18-4d7a-4e86-89f2-4945cae2ef79.png)


## Which point I want you to review particularly

## Memo
