### PR TITLE
fix: resolve endsWith is not a function error with style in reearth/core

### DIFF
--- a/src/core/mantle/evaluator/simple/expression/node.ts
+++ b/src/core/mantle/evaluator/simple/expression/node.ts
@@ -501,7 +501,9 @@ export class Node {
   }
 }
 
-function cleanseNumberStringInput(input: string): string {
+function cleanseNumberStringInput(input: any): any {
+  if (typeof input !== "string") return input;
+
   const reservedWords = ["%"]; // add more reserved words if needed
 
   for (const word of reservedWords) {


### PR DESCRIPTION
This is a fix for a issue observed while using the styling with `Number()` function whose input is not `string`