### PR TITLE
perf: consider geojson as both delegate and active data type in reearth/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
         "leaflet": "1.9.3",
         "localforage": "1.10.0",
         "lodash-es": "4.17.21",
+        "lru-cache": "8.0.4",
         "mini-svg-data-uri": "1.4.4",
         "parse-domain": "7.0.1",
         "quickjs-emscripten": "0.21.1",

--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -2,7 +2,7 @@ import { Entity, type DataSource, Color } from "cesium";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { KmlDataSource, CzmlDataSource, GeoJsonDataSource, useCesium } from "resium";
 
-import { ComputedFeature, DataType, evalFeature, Feature, guessType } from "@reearth/core/mantle";
+import { ComputedFeature, evalFeature, Feature, guessType } from "@reearth/core/mantle";
 import { requestIdleCallbackWithRequiredWork } from "@reearth/util/idle";
 
 import type { ResourceAppearance } from "../../..";
@@ -28,8 +28,6 @@ const comps = {
   czml: CzmlDataSource,
   geojson: GeoJsonDataSource,
 };
-
-const DataTypeListAllowsOnlyProperty: DataType[] = ["geojson"];
 
 type CachedFeature = {
   feature: Feature;
@@ -62,7 +60,7 @@ export default function Resource({
     const url = property?.url;
     return [
       type ?? (data?.type as ResourceAppearance["type"]),
-      url ?? (data && !DataTypeListAllowsOnlyProperty.includes(data.type) ? data?.url : undefined),
+      url ?? data?.url,
       !!data?.time?.updateClockOnLoad,
     ];
   }, [property, layer]);
@@ -132,6 +130,11 @@ export default function Resource({
     [updateClock, viewer?.clock],
   );
 
+  // convert hexCodeColorString to ColorValue?s
+  const strokeValue = stroke ? Color.fromCssColorString(stroke) : undefined;
+  const fillValue = fill ? Color.fromCssColorString(fill) : undefined;
+  const markerColorValue = markerColor ? Color.fromCssColorString(markerColor) : undefined;
+
   useEffect(() => {
     if (!viewer) return;
     cachedFeatures.current.forEach(f => {
@@ -157,11 +160,11 @@ export default function Resource({
       clampToGround={clampToGround}
       onChange={handleChange}
       onLoad={handleLoad}
-      stroke={Color.fromCssColorString(stroke ?? "white")}
-      fill={Color.fromCssColorString(fill ?? "transparent")}
+      stroke={strokeValue}
+      fill={fillValue}
       strokeWidth={strokeWidth}
       markerSize={markerSize}
-      markerColor={Color.fromCssColorString(markerColor ?? "white")}
+      markerColor={markerColorValue}
     />
   );
 }

--- a/src/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/src/core/engines/Cesium/Feature/Resource/index.tsx
@@ -131,9 +131,15 @@ export default function Resource({
   );
 
   // convert hexCodeColorString to ColorValue?s
-  const strokeValue = stroke ? Color.fromCssColorString(stroke) : undefined;
-  const fillValue = fill ? Color.fromCssColorString(fill) : undefined;
-  const markerColorValue = markerColor ? Color.fromCssColorString(markerColor) : undefined;
+  const strokeValue = useMemo(
+    () => (stroke ? Color.fromCssColorString(stroke) : undefined),
+    [stroke],
+  );
+  const fillValue = useMemo(() => (fill ? Color.fromCssColorString(fill) : undefined), [fill]);
+  const markerColorValue = useMemo(
+    () => (markerColor ? Color.fromCssColorString(markerColor) : undefined),
+    [markerColor],
+  );
 
   useEffect(() => {
     if (!viewer) return;

--- a/src/core/engines/Cesium/Feature/index.tsx
+++ b/src/core/engines/Cesium/Feature/index.tsx
@@ -74,7 +74,7 @@ const pickProperty = (k: keyof AppearanceTypes, layer: ComputedLayer) => {
 };
 
 const CACHED_COMPONENTS = new LRUCache<string, JSX.Element>({ max: 10000 });
-const FEATURE_DELETGATE_THRESHOLD = 6000;
+const FEATURE_DELEGATE_THRESHOLD = 6000;
 
 export default function Feature({
   layer,
@@ -82,7 +82,7 @@ export default function Feature({
   ...props
 }: FeatureComponentProps): JSX.Element | null {
   // Set the displayConfig based on the size of the feature collection array
-  if (layer.features?.length > FEATURE_DELETGATE_THRESHOLD) {
+  if (layer.features?.length > FEATURE_DELEGATE_THRESHOLD) {
     displayConfig.geojson = ["resource"];
   } else {
     displayConfig.geojson = "auto";

--- a/yarn.lock
+++ b/yarn.lock
@@ -13118,6 +13118,11 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lru-cache@8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-8.0.4.tgz#49fbbc46c0b4cedc36258885247f93dba341e7ec"
+  integrity sha512-E9FF6+Oc/uFLqZCuZwRKUzgFt5Raih6LfxknOSAVTjNkrCZkBf7DQCwJxZQgd9l4eHjIJDGR+E+1QKD1RhThPw==
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"


### PR DESCRIPTION
# Overview
The PR adds support for large `geojson` type of data.
With the current approach of considering `geojson` only works to a limit of around 14k featureCollection in a layer, any data containing more features gives a WebGL error which basically means that `Cesium` cannot handle any more individual graphics component i.e `PolygonGraphics`, `PolylineGraphics` etc. 

# Description
As of now I've added a threshold limit of `6000` for featureCollection size, for geojson to be considered as an `active` data format in NLS and the size is large we consider it as a `delegate` data format.

Pros:

- We can now accommodate very large geojson with this approach now.
- We also save alot of overhead.

Cons:

- We lose the ability to custom styling on this data.
- With this approach, we can only handle featureCollection of size < 50k which is not bad but not that ideal.


## Side Note 
I've also utilised a LRU cache and `useMemo` to prevent re:rendering of component on camera movement, which has made things quite snappy for me, feel free to try that.