### PR TITLE
fix: use core hook may get value incorrectly

### DIFF
--- a/src/util/use-core.ts
+++ b/src/util/use-core.ts
@@ -27,8 +27,7 @@ export const useCore = (
         ? !!data?.node?.property?.items.find(
             item =>
               item.__typename === "PropertyGroup" &&
-              item.fields[0].fieldId === "experimental_core" &&
-              item.fields[0].value,
+              item.fields.find(f => f.fieldId === "experimental_core" && f.value),
           )
         : false;
     return enable;


### PR DESCRIPTION
# Overview

`fields[0]` is not reliable since there's multiple experimental items now.
This may lead to recently created project can't apply useCore in earth editor.

## What I've done


## What I haven't done

## How I tested


## Screenshot

## Which point I want you to review particularly

## Memo
